### PR TITLE
fix: persist Airwallex intent id between create and confirm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .task
 .pre-commit-config.yaml
 
+# Local DB inspection helper (read-only penalty/charity queries)
+scripts/check-penalties.sh
+
 ### VisualStudioCode template
 .vscode/*
 !.vscode/settings.json

--- a/App/Modules/Penalty/Data/PenaltyRepository.cs
+++ b/App/Modules/Penalty/Data/PenaltyRepository.cs
@@ -185,6 +185,27 @@ public class PenaltyRepository(MainDbContext db, ILogger<PenaltyRepository> logg
     }
   }
 
+  public async Task<Result<Unit>> SetIntentId(Guid id, string paymentIntentId)
+  {
+    try
+    {
+      var penalty = await db.Penalties.Where(x => x.Id == id).FirstOrDefaultAsync();
+      if (penalty == null) return new Unit();
+      // Persist only the intent id from a successful create; status/attempts stay as-is
+      // (the row remains claimed/Processing for the rest of this pass). This makes the
+      // intent id durable across a confirm failure so the retry reconciles it.
+      penalty.PaymentIntentId = paymentIntentId;
+      penalty.UpdatedAt = DateTime.UtcNow;
+      await db.SaveChangesAsync();
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "SetIntentId failed for Id={Id} PaymentIntentId={PaymentIntentId}", id, paymentIntentId);
+      throw;
+    }
+  }
+
   public async Task<Result<Unit>> Bump(Guid id, string error)
   {
     try

--- a/App/Modules/Penalty/Data/PenaltyRepository.cs
+++ b/App/Modules/Penalty/Data/PenaltyRepository.cs
@@ -189,8 +189,10 @@ public class PenaltyRepository(MainDbContext db, ILogger<PenaltyRepository> logg
   {
     try
     {
-      var penalty = await db.Penalties.Where(x => x.Id == id).FirstOrDefaultAsync();
-      if (penalty == null) return new Unit();
+      // Fail loud if the row is gone: returning success here would let the caller proceed to
+      // confirm without a durable PaymentIntentId, reopening the duplicate_request hole.
+      var penalty = await db.Penalties.Where(x => x.Id == id).FirstOrDefaultAsync()
+        ?? throw new InvalidOperationException($"Cannot persist payment intent: penalty {id} was not found.");
       // Persist only the intent id from a successful create; status/attempts stay as-is
       // (the row remains claimed/Processing for the rest of this pass). This makes the
       // intent id durable across a confirm failure so the retry reconciles it.

--- a/Domain/Payment/IService.cs
+++ b/Domain/Payment/IService.cs
@@ -29,9 +29,13 @@ public interface IPaymentService
   //   the gateway intent is retrieved and reconciled (already SUCCEEDED -> returned as-is;
   //   confirmable -> confirmed) BEFORE any new intent is created, so settled money is
   //   never charged twice.
+  // onIntentCreated: invoked with the new intent id right after a fresh create succeeds
+  //   and BEFORE confirm, so the caller can persist it; this keeps the id durable across
+  //   a confirm failure so the retry reconciles the existing intent instead of re-creating.
   Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
-    string? idempotencyKey = null, string? existingIntentId = null);
+    string? idempotencyKey = null, string? existingIntentId = null,
+    Func<string, Task>? onIntentCreated = null);
 
   // Query operations
   Task<Result<IEnumerable<PaymentCustomerPrincipal>>> SearchCustomers(PaymentCustomerSearch search);

--- a/Domain/Payment/Service.cs
+++ b/Domain/Payment/Service.cs
@@ -162,7 +162,8 @@ public class PaymentService(
   // collapses onto one Airwallex intent.
   public Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
-    string? idempotencyKey = null, string? existingIntentId = null)
+    string? idempotencyKey = null, string? existingIntentId = null,
+    Func<string, Task>? onIntentCreated = null)
   {
     return repo.GetByUserId(userId)
       .Then(customer =>
@@ -201,13 +202,21 @@ public class PaymentService(
           IdempotencyKey = idempotencyKey
         };
         return gateway.CreatePaymentIntentAsync(createReq)
-          .ThenAwait(intent =>
-            intent.Status == "SUCCEEDED"
-              // Idempotent replay (same IdempotencyKey -> Airwallex request_id)
-              // returned the already-settled intent from a prior attempt: do not
-              // re-confirm, which would otherwise move money a second time.
-              ? intent.ToAsyncResult()
-              : gateway.ConfirmPaymentIntentAsync(intent.Id, r.PaymentConsentId!, r.AirwallexCustomerId));
+          .ThenAwait(async intent =>
+          {
+            // Idempotent replay (same IdempotencyKey -> Airwallex request_id) returned the
+            // already-settled intent from a prior attempt: do not re-confirm, which would
+            // otherwise move money a second time.
+            if (intent.Status == "SUCCEEDED") return intent.ToResult();
+
+            // Persist the freshly-created intent id BEFORE confirming, so a confirm failure
+            // (or crash) doesn't lose it. The next retry then reconciles THIS intent via
+            // existingIntentId instead of creating a new one, which would reuse the
+            // request_id and be rejected by Airwallex as duplicate_request.
+            if (onIntentCreated != null) await onIntentCreated(intent.Id);
+
+            return await gateway.ConfirmPaymentIntentAsync(intent.Id, r.PaymentConsentId!, r.AirwallexCustomerId);
+          });
       });
   }
 

--- a/Domain/Penalty/Repository.cs
+++ b/Domain/Penalty/Repository.cs
@@ -16,6 +16,11 @@ public interface IPenaltyRepository
   // Keep Pending, persist intent id from a requires-action create, set Attempts.
   Task<Result<Unit>> MarkPending(Guid id, string paymentIntentId, int attempts);
 
+  // Persist ONLY the PaymentIntentId from a freshly-created intent (no status/attempts
+  // change), so a subsequent confirm failure doesn't lose it and the retry reconciles
+  // this intent instead of creating a new one (which would reuse the request_id).
+  Task<Result<Unit>> SetIntentId(Guid id, string paymentIntentId);
+
   // Attempts += 1, set LastError, keep Pending (transient retry).
   Task<Result<Unit>> Bump(Guid id, string error);
 

--- a/Domain/Penalty/Service.cs
+++ b/Domain/Penalty/Service.cs
@@ -39,7 +39,15 @@ public class PenaltyService(
       await payment.ChargeStoredConsentAsync(
         rec.UserId, rec.Amount, $"Habit penalty {rec.HabitExecutionId}",
         idempotencyKey: p.Id.ToString(),
-        existingIntentId: rec.PaymentIntentId);
+        existingIntentId: rec.PaymentIntentId,
+        // Persist the intent id the moment it's created (before confirm) so a confirm
+        // failure doesn't lose it; a persistence failure surfaces so the attempt retries.
+        onIntentCreated: async intentId =>
+        {
+          var saved = await repo.SetIntentId(p.Id, intentId);
+          if (!saved.IsSuccess())
+            throw saved.FailureOrDefault() ?? new Exception($"SetIntentId failed for penalty {p.Id}");
+        });
 
     if (chargeResult.IsSuccess())
     {

--- a/IntTest/Penalty/Helpers.cs
+++ b/IntTest/Penalty/Helpers.cs
@@ -35,7 +35,8 @@ public sealed class StubPaymentService(Func<string, Money, string, Result<Paymen
 
   public Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
-    string? idempotencyKey = null, string? existingIntentId = null)
+    string? idempotencyKey = null, string? existingIntentId = null,
+    Func<string, Task>? onIntentCreated = null)
     => Task.FromResult(charge(userId, amount, description));
 
   public Task<Result<PaymentCustomerPrincipal>> CreateCustomerAsync(string userId)

--- a/IntTest/Penalty/Helpers.cs
+++ b/IntTest/Penalty/Helpers.cs
@@ -33,11 +33,48 @@ public sealed class StubPaymentService(Func<string, Money, string, Result<Paymen
   public static StubPaymentService Fails(Exception ex)
     => new((_, _, _) => ex);
 
-  public Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
+  // Round-trip stub: 1st charge (existingIntentId == null) "creates" an intent (emits the id
+  // via onIntentCreated, mirroring a successful create) then fails confirm; the 2nd charge
+  // (now called with existingIntentId set) reconciles to SUCCEEDED.
+  public static StubPaymentService CreatesThenFailsThenSucceeds(string intentId)
+  {
+    var calls = 0;
+    return new StubPaymentService((_, amount, _) =>
+    {
+      calls++;
+      return calls == 1
+        ? (Result<PaymentIntentResult>)new Exception("confirm 400 duplicate_request")
+        : new PaymentIntentResult
+        {
+          Id = intentId,
+          Status = "SUCCEEDED",
+          Amount = amount.Amount,
+          Currency = amount.Currency.Code,
+          CustomerId = "cus_stub",
+          MerchantOrderId = "mo_stub"
+        };
+    })
+    { EmitIntentIdOnFirstCreate = intentId };
+  }
+
+  // Set by CreatesThenFailsThenSucceeds: emit this id via onIntentCreated on the first
+  // (create) call so the caller persists it before the simulated confirm failure.
+  public string? EmitIntentIdOnFirstCreate { get; init; }
+
+  // Records the existingIntentId passed on each call, so a test can assert the retry
+  // reconciled the persisted intent (non-null) instead of re-creating (null).
+  public List<string?> ExistingIntentIdArgs { get; } = [];
+
+  public async Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
     string? idempotencyKey = null, string? existingIntentId = null,
     Func<string, Task>? onIntentCreated = null)
-    => Task.FromResult(charge(userId, amount, description));
+  {
+    ExistingIntentIdArgs.Add(existingIntentId);
+    if (EmitIntentIdOnFirstCreate != null && existingIntentId == null && onIntentCreated != null)
+      await onIntentCreated(EmitIntentIdOnFirstCreate);
+    return charge(userId, amount, description);
+  }
 
   public Task<Result<PaymentCustomerPrincipal>> CreateCustomerAsync(string userId)
     => throw new NotImplementedException();

--- a/IntTest/Penalty/PenaltyIntegrationTests.cs
+++ b/IntTest/Penalty/PenaltyIntegrationTests.cs
@@ -179,6 +179,48 @@ public class PenaltyIntegrationTests : IAsyncLifetime
   }
 
   [Fact]
+  public async Task ConfirmFailThenRetry_ReusesPersistedIntent_NoRecreate_ThenCharges()
+  {
+    if (_conn == null) { Assert.True(true, Skip); return; }
+
+    // Full round-trip regression for the duplicate_request fix:
+    //   pass 1: create-ok + confirm-fail -> intent id persisted, row bumped & still Pending
+    //   pass 2: drain re-reads the persisted id and passes it as existingIntentId
+    //           (reconcile, NOT a re-create) -> charge succeeds, charity credited.
+    var (userId, charityId) = await SeedUserAndCharity();
+    var executionId = await SeedExecution(userId, charityId);
+    (await Repo(_db).EnqueuePending(PendingRecord(executionId, userId, charityId, 100))).Get().Should().BeTrue();
+
+    var payment = StubPaymentService.CreatesThenFailsThenSucceeds("int_rt");
+
+    // Pass 1: confirm fails -> not charged, but intent id must be persisted. Each pass uses
+    // its own DbContext, mirroring the per-drain scoped context in the hosted service.
+    await using (var c1 = NewContext(_conn!))
+      ((int)await Service(Repo(c1), payment).ProcessPending(batchSize: 100, maxAttempts: 5)).Should().Be(0);
+    await using (var v1 = NewContext(_conn!))
+    {
+      var p1 = await v1.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId);
+      p1.PaymentIntentId.Should().Be("int_rt");                 // survived the confirm failure
+      p1.Status.Should().Be((int)PenaltyStatus.Pending);
+      p1.Attempts.Should().Be(1);
+    }
+
+    // Pass 2: reconcile the SAME intent and settle.
+    await using (var c2 = NewContext(_conn!))
+      ((int)await Service(Repo(c2), payment).ProcessPending(batchSize: 100, maxAttempts: 5)).Should().Be(1);
+
+    // The retry passed the persisted id as existingIntentId (no re-create with a fresh id).
+    payment.ExistingIntentIdArgs.Should().Equal([null, "int_rt"]);
+
+    await using var v2 = NewContext(_conn!);
+    var p2 = await v2.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId);
+    p2.Status.Should().Be((int)PenaltyStatus.Charged);
+    p2.PaymentIntentId.Should().Be("int_rt");
+    var bal = await v2.CharityBalances.AsNoTracking().SingleAsync(x => x.CharityId == charityId);
+    bal.AccruedCents.Should().Be(100);
+  }
+
+  [Fact]
   public async Task RunningTwice_DoesNotDoubleCharge()
   {
     if (_conn == null) { Assert.True(true, Skip); return; }

--- a/IntTest/Penalty/PenaltyIntegrationTests.cs
+++ b/IntTest/Penalty/PenaltyIntegrationTests.cs
@@ -30,7 +30,7 @@ namespace IntTest.Penalty;
 // wherever Postgres is available (CI / the later build phase).
 public class PenaltyIntegrationTests : IAsyncLifetime
 {
-  private const string Skip = "PENALTY_TEST_DB not set; skipping DB-backed penalty integration test.";
+  private const string SkipReason = "PENALTY_TEST_DB not set; skipping DB-backed penalty integration test.";
   private readonly string? _conn = Environment.GetEnvironmentVariable("PENALTY_TEST_DB");
   private MainDbContext _db = null!;
 
@@ -130,10 +130,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
       LastError = null
     };
 
-  [Fact]
+  [SkippableFact]
   public async Task OneFailedExecution_ChargedOnce_CreditsCharity()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);
@@ -157,10 +157,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balance.AccruedCents.Should().Be(500);
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task SetIntentId_PersistsIntentId_LeavesStatusAndAttemptsUntouched()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);
@@ -178,10 +178,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     p.Attempts.Should().Be(0);                               // attempts untouched
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task ConfirmFailThenRetry_ReusesPersistedIntent_NoRecreate_ThenCharges()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     // Full round-trip regression for the duplicate_request fix:
     //   pass 1: create-ok + confirm-fail -> intent id persisted, row bumped & still Pending
@@ -220,10 +220,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     bal.AccruedCents.Should().Be(100);
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task RunningTwice_DoesNotDoubleCharge()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);
@@ -247,10 +247,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balance.AccruedCents.Should().Be(500); // credited exactly once
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task MarkCharged_CalledTwice_CreditsCharityOnce()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);
@@ -277,10 +277,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balance.AccruedCents.Should().Be(500); // credited exactly once despite double MarkCharged
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task MarkCharged_BlocksOnHeldRowLock_ThenCreditsOnce()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);
@@ -316,10 +316,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balance.AccruedCents.Should().Be(500);
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task MarkCharged_ConcurrentSameCharityCurrency_NeverLosesUpdate()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     const int reps = 50;
     var (userId, charityId) = await SeedUserAndCharity();
@@ -361,10 +361,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balance.AccruedCents.Should().Be(reps * 5L); // every credit landed; no lost update
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task DifferentCurrenciesSameCharity_AccrueIntoSeparateRows()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var eSgd = await SeedExecution(userId, charityId);
@@ -391,10 +391,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     penalties.Should().HaveCount(2).And.OnlyContain(p => p.Status == (int)PenaltyStatus.Charged);
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task SameCurrencySameCharity_AccrueIntoOneRow()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var e1 = await SeedExecution(userId, charityId);
@@ -415,10 +415,10 @@ public class PenaltyIntegrationTests : IAsyncLifetime
     balances[0].AccruedCents.Should().Be(500); // 300 + 200 summed in place
   }
 
-  [Fact]
+  [SkippableFact]
   public async Task NoConsent_MarksSkipped_NoCredit()
   {
-    if (_conn == null) { Assert.True(true, Skip); return; }
+    Skip.If(_conn == null, SkipReason);
 
     var (userId, charityId) = await SeedUserAndCharity();
     var executionId = await SeedExecution(userId, charityId);

--- a/IntTest/Penalty/PenaltyIntegrationTests.cs
+++ b/IntTest/Penalty/PenaltyIntegrationTests.cs
@@ -158,6 +158,27 @@ public class PenaltyIntegrationTests : IAsyncLifetime
   }
 
   [Fact]
+  public async Task SetIntentId_PersistsIntentId_LeavesStatusAndAttemptsUntouched()
+  {
+    if (_conn == null) { Assert.True(true, Skip); return; }
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    var executionId = await SeedExecution(userId, charityId);
+    var repo = Repo(_db);
+    (await repo.EnqueuePending(PendingRecord(executionId, userId, charityId, 100))).Get().Should().BeTrue();
+
+    var id = await _db.Penalties.AsNoTracking().Where(x => x.UserId == userId).Select(x => x.Id).SingleAsync();
+
+    (await repo.SetIntentId(id, "int_persisted")).Get();
+
+    await using var verify = NewContext(_conn!);
+    var p = await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId);
+    p.PaymentIntentId.Should().Be("int_persisted");          // id written
+    p.Status.Should().Be((int)PenaltyStatus.Pending);        // status untouched
+    p.Attempts.Should().Be(0);                               // attempts untouched
+  }
+
+  [Fact]
   public async Task RunningTwice_DoesNotDoubleCharge()
   {
     if (_conn == null) { Assert.True(true, Skip); return; }

--- a/UnitTest/Payment/ChargeStoredConsentTests.cs
+++ b/UnitTest/Payment/ChargeStoredConsentTests.cs
@@ -1,0 +1,139 @@
+using CSharp_Result;
+using Domain.Payment;
+using FluentAssertions;
+using NodaMoney;
+using Xunit;
+
+namespace UnitTest.Payment;
+
+// Guards the duplicate_request fix: PaymentService.ChargeStoredConsentAsync must persist
+// the freshly-created intent id (via onIntentCreated) AFTER create succeeds and BEFORE
+// confirm, so a confirm failure doesn't lose it and retries reconcile the same intent.
+public class ChargeStoredConsentTests
+{
+  private const string UserId = "user-1";
+  private static readonly Money Amount = new(1.00m, Currency.FromCode("USD"));
+
+  private static PaymentCustomer VerifiedCustomer() => new()
+  {
+    Principal = new PaymentCustomerPrincipal
+    {
+      Id = Guid.NewGuid(),
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow,
+      Record = new PaymentCustomerRecord
+      {
+        UserId = UserId,
+        AirwallexCustomerId = "cus_1",
+        PaymentConsentId = "cst_1",
+        ConsentStatus = PaymentConsentStatus.Verified,
+        HasPaymentConsent = true
+      }
+    }
+  };
+
+  private static PaymentIntentResult Intent(string id, string status) => new()
+  {
+    Id = id,
+    Status = status,
+    Amount = Amount.Amount,
+    Currency = Amount.Currency.Code,
+    CustomerId = "cus_1",
+    MerchantOrderId = "mo_1"
+  };
+
+  [Fact]
+  public async Task CreateOk_ConfirmFails_PersistsIntentId_BeforeConfirm()
+  {
+    var gateway = new FakeGateway
+    {
+      CreateResult = Intent("int_new", "REQUIRES_PAYMENT_METHOD"),
+      ConfirmResult = new Exception("confirm 400 duplicate_request")
+    };
+    var svc = new PaymentService(new FakeCustomerRepo(VerifiedCustomer()), gateway);
+
+    string? persisted = null;
+    var res = await svc.ChargeStoredConsentAsync(
+      UserId, Amount, "penalty",
+      idempotencyKey: "pen-1",
+      onIntentCreated: id => { persisted = id; gateway.MarkPersist(); return Task.CompletedTask; });
+
+    // The created intent id was handed to the persistence hook...
+    persisted.Should().Be("int_new");
+    // ...before confirm ran (create -> persist -> confirm order)...
+    gateway.Calls.Should().ContainInOrder("create", "persist", "confirm");
+    // ...and the overall charge surfaces the confirm failure.
+    res.IsSuccess().Should().BeFalse();
+  }
+
+  [Fact]
+  public async Task RetryWithExistingIntent_ReconcilesNotRecreates()
+  {
+    var gateway = new FakeGateway
+    {
+      RetrieveResult = Intent("int_old", "REQUIRES_PAYMENT_METHOD"),
+      ConfirmResult = Intent("int_old", "SUCCEEDED")
+    };
+    var svc = new PaymentService(new FakeCustomerRepo(VerifiedCustomer()), gateway);
+
+    var hookCalled = false;
+    var res = await svc.ChargeStoredConsentAsync(
+      UserId, Amount, "penalty",
+      idempotencyKey: "pen-1",
+      existingIntentId: "int_old",
+      onIntentCreated: _ => { hookCalled = true; return Task.CompletedTask; });
+
+    res.IsSuccess().Should().BeTrue();
+    gateway.Calls.Should().NotContain("create"); // reused existing intent
+    hookCalled.Should().BeFalse();                // nothing new created -> hook not used
+  }
+
+  // --- Fakes ---
+
+  private sealed class FakeCustomerRepo(PaymentCustomer customer) : IPaymentCustomerRepository
+  {
+    public Task<Result<PaymentCustomer?>> GetByUserId(string userId)
+      => Task.FromResult<Result<PaymentCustomer?>>(customer);
+
+    public Task<Result<PaymentCustomer?>> GetById(Guid id) => throw new NotImplementedException();
+    public Task<Result<IEnumerable<PaymentCustomerPrincipal>>> Search(PaymentCustomerSearch search) => throw new NotImplementedException();
+    public Task<Result<PaymentCustomerPrincipal>> Create(string userId, string airwallexCustomerId) => throw new NotImplementedException();
+    public Task<Result<PaymentCustomerPrincipal?>> UpdatePaymentConsentByAirwallexCustomerId(
+      string airwallexCustomerId, string? paymentConsentId, PaymentConsentStatus? consentStatus) => throw new NotImplementedException();
+    public Task<Result<PaymentCustomerPrincipal?>> DisablePaymentConsentAsync(string userId) => throw new NotImplementedException();
+  }
+
+  private sealed class FakeGateway : IPaymentGateway
+  {
+    public List<string> Calls { get; } = [];
+    public Result<PaymentIntentResult>? CreateResult { get; init; }
+    public Result<PaymentIntentResult>? RetrieveResult { get; init; }
+    public Result<PaymentIntentResult>? ConfirmResult { get; init; }
+
+    public Task<Result<PaymentIntentResult>> CreatePaymentIntentAsync(CreatePaymentIntentRequest request)
+    {
+      Calls.Add("create");
+      return Task.FromResult(CreateResult!.Value);
+    }
+
+    public Task<Result<PaymentIntentResult>> RetrievePaymentIntentAsync(string paymentIntentId)
+    {
+      Calls.Add("retrieve");
+      return Task.FromResult(RetrieveResult!.Value);
+    }
+
+    public Task<Result<PaymentIntentResult>> ConfirmPaymentIntentAsync(string paymentIntentId, string paymentConsentId, string customerId)
+    {
+      Calls.Add("confirm");
+      return Task.FromResult(ConfirmResult!.Value);
+    }
+
+    public void MarkPersist() => Calls.Add("persist");
+
+    public Task<Result<string?>> GetCustomerIdByMerchantIdAsync(string merchantCustomerId) => throw new NotImplementedException();
+    public Task<Result<string>> CreateCustomerAsync(string merchantCustomerId) => throw new NotImplementedException();
+    public Task<Result<string>> GenerateClientSecretAsync(string customerId) => throw new NotImplementedException();
+    public Task<Result<PaymentConsentInfo[]>> GetVerifiedPaymentConsentsAsync(string customerId) => throw new NotImplementedException();
+    public Task<Result<Unit>> DisablePaymentConsentAsync(string paymentConsentId) => throw new NotImplementedException();
+  }
+}

--- a/UnitTest/Payment/ChargeStoredConsentTests.cs
+++ b/UnitTest/Payment/ChargeStoredConsentTests.cs
@@ -84,8 +84,11 @@ public class ChargeStoredConsentTests
       onIntentCreated: _ => { hookCalled = true; return Task.CompletedTask; });
 
     res.IsSuccess().Should().BeTrue();
-    gateway.Calls.Should().NotContain("create"); // reused existing intent
-    hookCalled.Should().BeFalse();                // nothing new created -> hook not used
+    gateway.Calls.Should().NotContain("create");                  // reused existing intent
+    gateway.Calls.Should().ContainInOrder("retrieve", "confirm"); // retrieved THEN confirmed
+    res.Get().Status.Should().Be("SUCCEEDED");                    // returns the confirmed intent
+    res.Get().Id.Should().Be("int_old");
+    hookCalled.Should().BeFalse();                                // nothing new created -> hook not used
   }
 
   // --- Fakes ---

--- a/UnitTest/Penalty/Fakes.cs
+++ b/UnitTest/Penalty/Fakes.cs
@@ -16,6 +16,7 @@ public sealed class FakePenaltyRepository(params PenaltyPrincipal[] pending) : I
   public List<PenaltyRecord> EnqueuedRecords { get; } = [];
   public List<(Guid Id, string PaymentIntentId)> MarkChargedCalls { get; } = [];
   public List<(Guid Id, string PaymentIntentId, int Attempts)> MarkPendingCalls { get; } = [];
+  public List<(Guid Id, string PaymentIntentId)> SetIntentIdCalls { get; } = [];
   public List<(Guid Id, string Error)> BumpCalls { get; } = [];
   public List<(Guid Id, string Error)> MarkFailedCalls { get; } = [];
   public List<Guid> MarkSkippedCalls { get; } = [];
@@ -44,6 +45,12 @@ public sealed class FakePenaltyRepository(params PenaltyPrincipal[] pending) : I
     return Task.FromResult<Result<Unit>>(new Unit());
   }
 
+  public Task<Result<Unit>> SetIntentId(Guid id, string paymentIntentId)
+  {
+    SetIntentIdCalls.Add((id, paymentIntentId));
+    return Task.FromResult<Result<Unit>>(new Unit());
+  }
+
   public Task<Result<Unit>> Bump(Guid id, string error)
   {
     BumpCalls.Add((id, error));
@@ -69,9 +76,15 @@ public sealed class FakePenaltyRepository(params PenaltyPrincipal[] pending) : I
 public sealed class FakePaymentService : IPaymentService
 {
   private readonly Func<string, Money, string, Result<PaymentIntentResult>> _charge;
+  // If set, ChargeStoredConsentAsync invokes onIntentCreated with this id before returning,
+  // simulating "create succeeded, then confirm did X".
+  private readonly string? _emitIntentId;
 
-  private FakePaymentService(Func<string, Money, string, Result<PaymentIntentResult>> charge)
-    => _charge = charge;
+  private FakePaymentService(Func<string, Money, string, Result<PaymentIntentResult>> charge, string? emitIntentId = null)
+  {
+    _charge = charge;
+    _emitIntentId = emitIntentId;
+  }
 
   public List<(string UserId, Money Amount, string Description)> ChargeCalls { get; } = [];
 
@@ -92,12 +105,20 @@ public sealed class FakePaymentService : IPaymentService
   public static FakePaymentService Fails(Exception ex)
     => new((_, _, _) => ex);
 
-  public Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
+  // Simulates: create intent succeeded (emits intentId via onIntentCreated), then the
+  // subsequent confirm failed with ex. Mirrors the real bug scenario.
+  public static FakePaymentService CreatesThenFails(string intentId, Exception ex)
+    => new((_, _, _) => ex, emitIntentId: intentId);
+
+  public async Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
-    string? idempotencyKey = null, string? existingIntentId = null)
+    string? idempotencyKey = null, string? existingIntentId = null,
+    Func<string, Task>? onIntentCreated = null)
   {
     ChargeCalls.Add((userId, amount, description));
-    return Task.FromResult(_charge(userId, amount, description));
+    if (_emitIntentId != null && onIntentCreated != null)
+      await onIntentCreated(_emitIntentId);
+    return _charge(userId, amount, description);
   }
 
   // --- Unused members of the contract (drain never invokes these) ---

--- a/UnitTest/Penalty/PenaltyServiceTests.cs
+++ b/UnitTest/Penalty/PenaltyServiceTests.cs
@@ -184,6 +184,29 @@ public class PenaltyServiceTests
   }
 
   [Fact]
+  public async Task ConfirmFailsAfterCreate_PersistsIntentId_SoRetryDoesNotRecreate()
+  {
+    // Regression (Airwallex duplicate_request): create-intent succeeded but the follow-up
+    // confirm failed. The intent id MUST be persisted (SetIntentId) so the next attempt
+    // reconciles the EXISTING intent instead of re-creating with the same request_id.
+    var pending = Pending(attempts: 0);
+    var repo = new FakePenaltyRepository(pending);
+    var payment = FakePaymentService.CreatesThenFails("pi_created", new Exception("confirm 400"));
+    var svc = Build(repo, payment);
+
+    var res = await svc.ProcessPending(batchSize: 10, maxAttempts: 5);
+
+    res.IsSuccess().Should().BeTrue();
+    // Intent id saved even though the overall charge failed.
+    repo.SetIntentIdCalls.Should().ContainSingle();
+    repo.SetIntentIdCalls[0].Should().Be((pending.Id, "pi_created"));
+    // Confirm failed transiently (below max) -> bumped for retry, not charged/failed.
+    repo.BumpCalls.Should().ContainSingle();
+    repo.MarkChargedCalls.Should().BeEmpty();
+    repo.MarkFailedCalls.Should().BeEmpty();
+  }
+
+  [Fact]
   public async Task TransientError_AtMax_MarksFailed()
   {
     var pending = Pending(attempts: 4); // attempts+1 == 5 >= 5


### PR DESCRIPTION
## Problem
Habit penalties never charge on real Airwallex (found via pichu e2e). Charges fail with **400 `duplicate_request`** — "request ID has been used previously."

**Root cause:** `ChargeStoredConsentAsync` runs create-intent + confirm-intent back-to-back with **no DB write between them**. When create succeeds but confirm fails, the created intent id is thrown away (`Penalties.PaymentIntentId` stays `null`). The next retry then **re-creates** the intent with the same `request_id` (the penalty id) → Airwallex rejects the reused id.

## Fix
Persist the intent id the moment it's created, **before** confirm.
- `IPenaltyRepository.SetIntentId(penaltyId, intentId)` — writes **only** `PaymentIntentId` (status/attempts untouched; the retry branch already keys off `PaymentIntentId` presence, not status).
- `onIntentCreated` hook on `ChargeStoredConsentAsync`, invoked right after a fresh create succeeds and **before** confirm. `ProcessOne` wires it to `SetIntentId`.

Result: a failed confirm keeps the intent id → the retry reconciles the **same** intent (retrieve + confirm) → `request_id` used once → no more `duplicate_request`.

## Tests
- **Payment-level** (`UnitTest/Payment/ChargeStoredConsentTests`): create-ok + confirm-fail → id persisted **before** confirm; and retry with existing intent reconciles (no re-create).
- **Penalty wiring** (`UnitTest/Penalty`): a charge that creates-then-fails persists the intent id.
- **Real-DB** (`IntTest/Penalty`): `SetIntentId` writes the id, leaves status/attempts.

All unit + integration tests pass locally (local Postgres).

## Notes
- Confirm's `request_id` left as-is (`confirm-{intentId}`) for now — validate on pichu first.
- The 8 already-Failed penalties on pichu have **burned** request_ids and won't retro-charge; validate with a fresh penalty after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment retry reconciliation: after a newly created payment intent, the intent id is persisted before confirmation, so retries won’t duplicate intent creation.
  * Pending penalties now preserve the reconciliable intent id without changing status or attempt counts, even when confirmation fails.
  * Existing-intent retry flows no longer re-run the intent creation step.
* **Tests**
  * Added unit and integration coverage for intent-id persistence, callback timing/order, and retry behavior.
* **Chores**
  * Updated local ignore rules for a helper script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->