### PR TITLE
fix: drop triggered_by from Airwallex confirm for consent-based MIT

### DIFF
--- a/App/Modules/Payment/Airwallex/ReqModels.cs
+++ b/App/Modules/Payment/Airwallex/ReqModels.cs
@@ -40,13 +40,10 @@ public record AirwallexConfirmPaymentIntentReq
   [JsonPropertyName("customer_id")]
   public required string CustomerId { get; init; }
 
-  // Off-session merchant-initiated transaction (MIT): the penalty is charged by a
-  // background job with no customer present. Without "merchant" Airwallex treats it
-  // as customer-initiated and can demand customer action (e.g. 3DS), which can never
-  // settle off-session. The scheduled/unscheduled distinction lives on the consent
-  // (next_triggered_by), not here.
-  [JsonPropertyName("triggered_by")]
-  public string TriggeredBy { get; init; } = "merchant";
+  // NOTE: do NOT send a top-level "triggered_by" here. For a consent-based MIT charge
+  // Airwallex derives merchant-vs-customer from the consent's next_triggered_by (set to
+  // "merchant" when the card was saved). Sending triggered_by makes Airwallex demand a
+  // payment_method.id and reject the confirm with a validation_error.
 
   // Airwallex requires a syntactically valid return_url even though an off-session
   // MIT charge never redirects.

--- a/App/Modules/Payment/Data/AirwallexGateway.cs
+++ b/App/Modules/Payment/Data/AirwallexGateway.cs
@@ -115,8 +115,9 @@ public class AirwallexGateway(AirwallexClient client) : IPaymentGateway
       PaymentConsentId = paymentConsentId,
       CustomerId = customerId,
       ReturnUrl = ReturnUrl,
-      // TriggeredBy ("merchant") and PaymentMethodOptions (final_auth + auto_capture)
-      // use their MIT defaults so the off-session penalty charge actually captures.
+      // No triggered_by: the consent's next_triggered_by ("merchant") designates the MIT.
+      // PaymentMethodOptions (final_auth + auto_capture) use their defaults so a successful
+      // confirm actually captures the off-session penalty charge.
     };
 
     return await client

--- a/UnitTest/Payment/AirwallexConfirmReqTests.cs
+++ b/UnitTest/Payment/AirwallexConfirmReqTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using App.Modules.Payment.Airwallex;
+using FluentAssertions;
+using Xunit;
+
+namespace UnitTest.Payment;
+
+// Regression: a consent-based MIT confirm must NOT send a top-level triggered_by.
+// Airwallex derives merchant-vs-customer from the consent's next_triggered_by; sending
+// triggered_by makes it demand a payment_method.id and reject with a validation_error.
+public class AirwallexConfirmReqTests
+{
+  [Fact]
+  public void ConfirmRequest_OmitsTriggeredBy_KeepsConsentAndRequestId()
+  {
+    var req = new AirwallexConfirmPaymentIntentReq
+    {
+      RequestId = "confirm-int_1",
+      PaymentConsentId = "cst_1",
+      CustomerId = "cus_1",
+      ReturnUrl = "https://atomi.cloud"
+    };
+
+    // Mirror the client's serialization (JsonContent.Create uses web defaults) so this
+    // guards the real wire payload, not just default-option behavior.
+    var json = JsonSerializer.Serialize(req, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+    json.Should().NotContain("triggered_by");        // MIT comes from the consent, not here
+    json.Should().Contain("\"payment_consent_id\":\"cst_1\"");
+    json.Should().Contain("\"request_id\":\"confirm-int_1\"");
+  }
+}


### PR DESCRIPTION
## Problem
After the intent-id persistence fix (#50), pichu's confirm step ran cleanly for the first time and revealed a second, real bug. Airwallex rejects the **confirm** with:
> `validation_error`: "triggered_by should not be set, payment_method.id should be provided when triggered_by is set"

## Root cause
The confirm request (`AirwallexConfirmPaymentIntentReq`) sent a top-level **`triggered_by: "merchant"`**. For a **consent-based MIT** charge, Airwallex derives merchant-vs-customer from the **consent's `next_triggered_by`** — which the frontend already sets to `merchant` when the card is saved (`alcohol.argon … use-payment-consent.ts`: `recurringOptions.next_triggered_by: 'merchant'`). Sending `triggered_by` at confirm is only valid with a raw `payment_method.id`, so Airwallex rejects it.

## Fix
- Remove `triggered_by` from `AirwallexConfirmPaymentIntentReq` — let the consent drive the MIT designation.
- Add a serialization test asserting the confirm payload **omits** `triggered_by` and keeps `payment_consent_id`/`request_id`.

## Validation
- Consent confirmed created MIT (`next_triggered_by: 'merchant'`, `merchant_trigger_reason: 'unscheduled'`, USD) — so removing `triggered_by` won't make it customer-initiated.
- Will verify on pichu sandbox by retrying a fresh penalty post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Airwallex payment confirmation requests to stop sending the `triggered_by` field.
  * Kept required consent and request details intact when confirming payments.
  * Added regression coverage to ensure the request payload stays correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->