### PR TITLE
fix: make optional Airwallex payment-intent response fields nullable

### DIFF
--- a/App/Modules/Payment/Airwallex/ResModels.cs
+++ b/App/Modules/Payment/Airwallex/ResModels.cs
@@ -73,8 +73,13 @@ public record AirwallexPaymentIntentRes
   [JsonPropertyName("id")]
   public required string Id { get; init; }
 
+  // Conditionally present (and unused downstream): not echoed on every payment-intent
+  // response. e.g. an off-session MIT confirm omits client_secret. Keeping these required
+  // makes System.Text.Json throw when they're absent, crashing the charge after the money
+  // has already moved. Only id/amount/currency/status/customer_id/merchant_order_id are
+  // guaranteed + read, so the rest are optional.
   [JsonPropertyName("request_id")]
-  public required string RequestId { get; init; }
+  public string? RequestId { get; init; }
 
   [JsonPropertyName("amount")]
   public required decimal Amount { get; init; }
@@ -89,13 +94,13 @@ public record AirwallexPaymentIntentRes
   public required string Status { get; init; }
 
   [JsonPropertyName("captured_amount")]
-  public required decimal CapturedAmount { get; init; }
+  public decimal? CapturedAmount { get; init; }
 
   [JsonPropertyName("customer_id")]
   public required string CustomerId { get; init; }
 
   [JsonPropertyName("client_secret")]
-  public required string ClientSecret { get; init; }
+  public string? ClientSecret { get; init; }
 }
 
 public record AirwallexPaymentConsentRes

--- a/UnitTest/Payment/AirwallexPaymentIntentResTests.cs
+++ b/UnitTest/Payment/AirwallexPaymentIntentResTests.cs
@@ -1,0 +1,58 @@
+using App.Modules.Payment.Airwallex;
+using App.Utility;
+using FluentAssertions;
+using Xunit;
+
+namespace UnitTest.Payment;
+
+// Regression: an off-session MIT confirm response omits client_secret (and may omit
+// request_id / captured_amount). The shared AirwallexPaymentIntentRes must parse without
+// them — requiring them threw a JsonException that crashed the charge AFTER the money had
+// already moved at Airwallex. Uses the real Utils.ToObj path the client uses.
+public class AirwallexPaymentIntentResTests
+{
+  [Fact]
+  public void ToObj_ConfirmResponseMissingOptionalFields_Parses()
+  {
+    // Shape of a real MIT confirm response: no client_secret / request_id / captured_amount.
+    var json = """
+      {
+        "id": "int_hkdmsgmf8",
+        "amount": 1.00,
+        "currency": "USD",
+        "merchant_order_id": "pen-1",
+        "status": "SUCCEEDED",
+        "customer_id": "cus_1"
+      }
+      """;
+
+    var act = () => json.ToObj<AirwallexPaymentIntentRes>();
+
+    act.Should().NotThrow();
+    var res = json.ToObj<AirwallexPaymentIntentRes>();
+    res.Id.Should().Be("int_hkdmsgmf8");
+    res.Status.Should().Be("SUCCEEDED");
+    res.CustomerId.Should().Be("cus_1");
+    res.MerchantOrderId.Should().Be("pen-1");
+    res.ClientSecret.Should().BeNull();   // absent on MIT confirm -> optional
+    res.RequestId.Should().BeNull();
+    res.CapturedAmount.Should().BeNull();
+  }
+
+  [Fact]
+  public void ToObj_FullResponse_StillPopulatesOptionalFields()
+  {
+    var json = """
+      {
+        "id": "int_1", "request_id": "req_1", "amount": 2.50, "currency": "USD",
+        "merchant_order_id": "mo_1", "status": "REQUIRES_PAYMENT_METHOD",
+        "captured_amount": 0.00, "customer_id": "cus_1", "client_secret": "cs_1"
+      }
+      """;
+
+    var res = json.ToObj<AirwallexPaymentIntentRes>();
+    res.RequestId.Should().Be("req_1");
+    res.ClientSecret.Should().Be("cs_1");
+    res.CapturedAmount.Should().Be(0.00m);
+  }
+}


### PR DESCRIPTION
## Problem
`AirwallexPaymentIntentRes` is one shared model parsed from **create / retrieve / confirm** payment-intent responses, but it marks `client_secret` (plus `request_id`, `captured_amount`) as **`required`**. An off-session **MIT confirm** response omits `client_secret`, so `System.Text.Json` threw:
`missing required properties, including the following: client_secret`
— while parsing a **200** confirm response, i.e. **after the charge had already settled** at Airwallex. The crash left the penalty stuck `Processing`; only fix #1's retrieve + `SUCCEEDED` reconcile on the next drain recovered it (and avoided a double-charge).

## Fix
- Make `client_secret`, `request_id`, `captured_amount` **optional** (`string?` / `decimal?`). They're **never read** downstream — the gateway maps only `id/status/amount/currency/customer_id/merchant_order_id`.
- Add a test that the shared model parses a confirm response **missing** `client_secret` (+ a full response still populates them).

## Found on pichu
Surfaced after #51 let confirm reach `200` for the first time. Validated live: the $1 sandbox charge eventually settled (charity credited) via the reconcile path — this fix removes the crash so it settles on the **first** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)