### PR TITLE
fix: isolate per-penalty failures in the drain + clear LastError on charge

### DIFF
--- a/App/Modules/Penalty/Data/PenaltyRepository.cs
+++ b/App/Modules/Penalty/Data/PenaltyRepository.cs
@@ -123,6 +123,7 @@ public class PenaltyRepository(MainDbContext db, ILogger<PenaltyRepository> logg
 
       penalty.Status = (int)PenaltyStatus.Charged;
       penalty.PaymentIntentId = paymentIntentId;
+      penalty.LastError = null; // clear any stale failure from earlier retries now that it settled
       penalty.UpdatedAt = DateTime.UtcNow;
 
       // Upsert the (charity, currency) accrual ledger in place. The balance is keyed

--- a/Domain/Penalty/Service.cs
+++ b/Domain/Penalty/Service.cs
@@ -19,7 +19,33 @@ public class PenaltyService(
         var results = new List<Result<int>>();
         foreach (var p in pending)
         {
-          results.Add(await this.ProcessOne(p, maxAttempts));
+          try
+          {
+            results.Add(await this.ProcessOne(p, maxAttempts));
+          }
+          catch (OperationCanceledException)
+          {
+            // A host shutdown / cancellation must abort the drain, not be turned into a Bump.
+            throw;
+          }
+          catch (Exception ex)
+          {
+            // Isolate per penalty: an unexpected throw (e.g. a malformed gateway response or
+            // an auth blip) must not abort the whole batch and strand the other claimed rows.
+            // Record it against this penalty and keep draining the rest.
+            logger.LogError(ex, "ProcessOne threw for penalty {Id}; isolating and continuing", p.Id);
+            try
+            {
+              await (p.Record.Attempts + 1 >= maxAttempts
+                ? repo.MarkFailed(p.Id, $"unhandled: {ex.Message}")
+                : repo.Bump(p.Id, $"unhandled: {ex.Message}"));
+            }
+            catch (Exception inner)
+            {
+              logger.LogError(inner, "Failed to record isolation for penalty {Id}", p.Id);
+            }
+            results.Add(0);
+          }
         }
 
         return results

--- a/IntTest/Penalty/PenaltyIntegrationTests.cs
+++ b/IntTest/Penalty/PenaltyIntegrationTests.cs
@@ -221,6 +221,28 @@ public class PenaltyIntegrationTests : IAsyncLifetime
   }
 
   [SkippableFact]
+  public async Task MarkCharged_ClearsStaleLastError()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    var executionId = await SeedExecution(userId, charityId);
+    (await Repo(_db).EnqueuePending(PendingRecord(executionId, userId, charityId, 100))).Get().Should().BeTrue();
+    var id = await _db.Penalties.AsNoTracking().Where(x => x.UserId == userId).Select(x => x.Id).SingleAsync();
+
+    // A prior failed attempt left a stale error; a successful charge must clear it.
+    await using (var c1 = NewContext(_conn!))
+      (await Repo(c1).Bump(id, "stale 401 Unauthorized")).Get();
+    await using (var c2 = NewContext(_conn!))
+      (await Repo(c2).MarkCharged(id, "pi_ok")).Get();
+
+    await using var verify = NewContext(_conn!);
+    var p = await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId);
+    p.Status.Should().Be((int)PenaltyStatus.Charged);
+    p.LastError.Should().BeNull(); // cleared on success
+  }
+
+  [SkippableFact]
   public async Task RunningTwice_DoesNotDoubleCharge()
   {
     Skip.If(_conn == null, SkipReason);

--- a/UnitTest/Penalty/Fakes.cs
+++ b/UnitTest/Penalty/Fakes.cs
@@ -80,6 +80,11 @@ public sealed class FakePaymentService : IPaymentService
   // simulating "create succeeded, then confirm did X".
   private readonly string? _emitIntentId;
 
+  // If set, the FIRST ChargeStoredConsentAsync call throws (simulates an unhandled gateway
+  // exception, e.g. a malformed response); later calls run normally.
+  public Exception? ThrowOnFirstCall { get; init; }
+  private int _calls;
+
   private FakePaymentService(Func<string, Money, string, Result<PaymentIntentResult>> charge, string? emitIntentId = null)
   {
     _charge = charge;
@@ -110,12 +115,27 @@ public sealed class FakePaymentService : IPaymentService
   public static FakePaymentService CreatesThenFails(string intentId, Exception ex)
     => new((_, _, _) => ex, emitIntentId: intentId);
 
+  // First call throws (unhandled), subsequent calls succeed — to test batch isolation.
+  public static FakePaymentService ThrowsOnFirstThenSucceeds(Exception ex, string intentId)
+    => new((_, amount, _) => new PaymentIntentResult
+    {
+      Id = intentId,
+      Status = "SUCCEEDED",
+      Amount = amount.Amount,
+      Currency = amount.Currency.Code,
+      CustomerId = "cus_fake",
+      MerchantOrderId = "mo_fake"
+    })
+    { ThrowOnFirstCall = ex };
+
   public async Task<Result<PaymentIntentResult>> ChargeStoredConsentAsync(
     string userId, Money amount, string description,
     string? idempotencyKey = null, string? existingIntentId = null,
     Func<string, Task>? onIntentCreated = null)
   {
     ChargeCalls.Add((userId, amount, description));
+    if (ThrowOnFirstCall != null && _calls++ == 0)
+      throw ThrowOnFirstCall;
     if (_emitIntentId != null && onIntentCreated != null)
       await onIntentCreated(_emitIntentId);
     return _charge(userId, amount, description);

--- a/UnitTest/Penalty/PenaltyServiceTests.cs
+++ b/UnitTest/Penalty/PenaltyServiceTests.cs
@@ -184,6 +184,25 @@ public class PenaltyServiceTests
   }
 
   [Fact]
+  public async Task ProcessOneThrows_IsolatedToThatPenalty_BatchKeepsDraining()
+  {
+    // Regression: an unhandled throw on one penalty (e.g. a malformed gateway response) must
+    // NOT abort the whole batch and strand the rest. The throwing row is recorded (bumped);
+    // the next row still charges.
+    var p1 = Pending();
+    var p2 = Pending();
+    var repo = new FakePenaltyRepository(p1, p2);
+    var payment = FakePaymentService.ThrowsOnFirstThenSucceeds(new Exception("malformed response"), "pi_ok");
+    var svc = Build(repo, payment);
+
+    var res = await svc.ProcessPending(batchSize: 10, maxAttempts: 5);
+
+    res.IsSuccess().Should().BeTrue();                                       // pass did NOT crash
+    repo.BumpCalls.Should().ContainSingle().Which.Id.Should().Be(p1.Id);     // p1 throw -> recorded
+    repo.MarkChargedCalls.Should().ContainSingle().Which.Should().Be((p2.Id, "pi_ok")); // p2 still charged
+  }
+
+  [Fact]
   public async Task ConfirmFailsAfterCreate_PersistsIntentId_SoRetryDoesNotRecreate()
   {
     // Regression (Airwallex duplicate_request): create-intent succeeded but the follow-up


### PR DESCRIPTION
Two robustness fixes surfaced while validating penalty charges on pichu (not correctness bugs — the charge already works after #50/#51/#52).

## 1. Don't crash the whole drain on one penalty
`ProcessPending` claims a **batch** and loops `ProcessOne`. An **unhandled throw** on one penalty (e.g. a malformed gateway response, or an auth blip) previously propagated out and **aborted the entire pass** (`PenaltyProcessorHostedService failed`), leaving the claimed rows stuck `Processing` until the stale-lease reclaimed them — and skipping every later penalty in the batch.

**Fix:** wrap each `ProcessOne` in try/catch — the throwing row is recorded (`Bump`, or `MarkFailed` at max attempts) and the loop **keeps draining** the rest.

## 2. Clear `LastError` on a successful charge
`MarkCharged` didn't clear `LastError`, so a charged penalty kept a **stale** failure string from an earlier retry (e.g. a transient `401`) — making a settled row look failed.

**Fix:** `MarkCharged` sets `LastError = null`.

## Tests
- Unit: a batch where the **first** penalty throws still **charges the second** (isolation).
- Int (real DB): `MarkCharged` **nulls** a prior `LastError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)