### PR TITLE
chore: point pichu Pledge at sandbox (api-staging.pledge.to)

### DIFF
--- a/App/Config/settings.pichu.yaml
+++ b/App/Config/settings.pichu.yaml
@@ -37,7 +37,7 @@ HttpClient:
   LOGTO:
     BaseAddress: https://api.lithium.alcohol.pichu.cluster.atomi.cloud
   PLEDGE:
-    BaseAddress: https://api.pledge.to
+    BaseAddress: https://api-staging.pledge.to
     Timeout: 60
     BearerAuth: supersecret
   AIRWALLEX:

--- a/infra/api_chart/app/settings.pichu.yaml
+++ b/infra/api_chart/app/settings.pichu.yaml
@@ -37,7 +37,7 @@ HttpClient:
   LOGTO:
     BaseAddress: https://api.lithium.alcohol.pichu.cluster.atomi.cloud
   PLEDGE:
-    BaseAddress: https://api.pledge.to
+    BaseAddress: https://api-staging.pledge.to
     Timeout: 60
     BearerAuth: supersecret
   AIRWALLEX:

--- a/infra/migration_chart/app/settings.pichu.yaml
+++ b/infra/migration_chart/app/settings.pichu.yaml
@@ -37,7 +37,7 @@ HttpClient:
   LOGTO:
     BaseAddress: https://api.lithium.alcohol.pichu.cluster.atomi.cloud
   PLEDGE:
-    BaseAddress: https://api.pledge.to
+    BaseAddress: https://api-staging.pledge.to
     Timeout: 60
     BearerAuth: supersecret
   AIRWALLEX:


### PR DESCRIPTION
Switches pichu's `PLEDGE.BaseAddress` from production (`api.pledge.to`) to **sandbox** (`api-staging.pledge.to`), matching pichu's sandbox posture (Airwallex already uses `api-demo`).

**Why:** read-only catalog sync against prod was fine, but the upcoming **charity disbursement** (donations = writes) must hit Pledge's sandbox or it would move **real money**. (Prereq for ticket 86ey38q33 / subtask 86ey392bh.)

**Files:** `App/Config/settings.pichu.yaml` + the config-synced `infra/api_chart` & `infra/migration_chart` mirrors.

## ⚠️ Deploy coordination
- The Pledge **sandbox uses separate API keys**. The pichu `ATOMI_HTTPCLIENT__PLEDGE__BEARERAUTH` secret in Infisical is currently a **prod** key → it will **401** against staging.
- **Before/with deploy:** set that Infisical secret (pichu env) to a **Pledge sandbox key** (from https://staging.pledge.to/impact-hub → Pledge APIs).
- Catalog sync is **admin-triggered (not scheduled)**, so merging/deploying this alone won't auto-break reads — but a sync/donation won't work until the sandbox key is in place.
- After the key lands: re-sync the charity catalog from staging (prod org IDs won't exist in sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s API endpoint configuration to use the staging service URL instead of the production URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->