### PR TITLE
feat: pay out accrued penalties to charities via Pledge donations

### DIFF
--- a/App/Config/settings.pichu.yaml
+++ b/App/Config/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
+# run the disbursement worker here. Donations hit the Pledge sandbox, never production.
+Disbursement:
+  Enabled: true
+
 Auth:
   Enabled: true
   Settings:

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -215,3 +215,12 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+Disbursement:
+  Enabled: false
+  MinPayoutCents: 0
+  MaxGroupsPerRun: 100
+  DonorFirstName: LazyTax
+  DonorLastName: Donations
+  DonorEmail: donations@lazytax.club

--- a/App/Migrations/20260629073603_AddDisbursement.Designer.cs
+++ b/App/Migrations/20260629073603_AddDisbursement.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629073603_AddDisbursement")]
+    partial class AddDisbursement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260629073603_AddDisbursement.cs
+++ b/App/Migrations/20260629073603_AddDisbursement.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDisbursement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "DisbursementId",
+                table: "Penalties",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Disbursements",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CharityId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Currency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    AmountCents = table.Column<long>(type: "bigint", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    PledgeOrganizationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ProviderDonationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Attempts = table.Column<int>(type: "integer", nullable: false),
+                    LastError = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Disbursements", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Disbursements_Charities_CharityId",
+                        column: x => x.CharityId,
+                        principalTable: "Charities",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Penalties_DisbursementId",
+                table: "Penalties",
+                column: "DisbursementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Penalties_Status_DisbursementId",
+                table: "Penalties",
+                columns: new[] { "Status", "DisbursementId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Disbursements_CharityId",
+                table: "Disbursements",
+                column: "CharityId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Disbursements_Status",
+                table: "Disbursements",
+                column: "Status");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Penalties_Disbursements_DisbursementId",
+                table: "Penalties",
+                column: "DisbursementId",
+                principalTable: "Disbursements",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Penalties_Disbursements_DisbursementId",
+                table: "Penalties");
+
+            migrationBuilder.DropTable(
+                name: "Disbursements");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Penalties_DisbursementId",
+                table: "Penalties");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Penalties_Status_DisbursementId",
+                table: "Penalties");
+
+            migrationBuilder.DropColumn(
+                name: "DisbursementId",
+                table: "Penalties");
+        }
+    }
+}

--- a/App/Migrations/20260629073603_AddDisbursement.cs
+++ b/App/Migrations/20260629073603_AddDisbursement.cs
@@ -1,99 +1,99 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace App.Migrations
 {
+  /// <inheritdoc />
+  public partial class AddDisbursement : Migration
+  {
     /// <inheritdoc />
-    public partial class AddDisbursement : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<Guid>(
-                name: "DisbursementId",
-                table: "Penalties",
-                type: "uuid",
-                nullable: true);
+      migrationBuilder.AddColumn<Guid>(
+          name: "DisbursementId",
+          table: "Penalties",
+          type: "uuid",
+          nullable: true);
 
-            migrationBuilder.CreateTable(
-                name: "Disbursements",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    CharityId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Currency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
-                    AmountCents = table.Column<long>(type: "bigint", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
-                    PledgeOrganizationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
-                    ProviderDonationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
-                    Attempts = table.Column<int>(type: "integer", nullable: false),
-                    LastError = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
-                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Disbursements", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Disbursements_Charities_CharityId",
-                        column: x => x.CharityId,
-                        principalTable: "Charities",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+      migrationBuilder.CreateTable(
+          name: "Disbursements",
+          columns: table => new
+          {
+            Id = table.Column<Guid>(type: "uuid", nullable: false),
+            CharityId = table.Column<Guid>(type: "uuid", nullable: false),
+            Currency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+            AmountCents = table.Column<long>(type: "bigint", nullable: false),
+            Status = table.Column<int>(type: "integer", nullable: false),
+            PledgeOrganizationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+            ProviderDonationId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+            Attempts = table.Column<int>(type: "integer", nullable: false),
+            LastError = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+            CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+            UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+          },
+          constraints: table =>
+          {
+            table.PrimaryKey("PK_Disbursements", x => x.Id);
+            table.ForeignKey(
+                      name: "FK_Disbursements_Charities_CharityId",
+                      column: x => x.CharityId,
+                      principalTable: "Charities",
+                      principalColumn: "Id",
+                      onDelete: ReferentialAction.Cascade);
+          });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Penalties_DisbursementId",
-                table: "Penalties",
-                column: "DisbursementId");
+      migrationBuilder.CreateIndex(
+          name: "IX_Penalties_DisbursementId",
+          table: "Penalties",
+          column: "DisbursementId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Penalties_Status_DisbursementId",
-                table: "Penalties",
-                columns: new[] { "Status", "DisbursementId" });
+      migrationBuilder.CreateIndex(
+          name: "IX_Penalties_Status_DisbursementId",
+          table: "Penalties",
+          columns: ["Status", "DisbursementId"]);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Disbursements_CharityId",
-                table: "Disbursements",
-                column: "CharityId");
+      migrationBuilder.CreateIndex(
+          name: "IX_Disbursements_CharityId",
+          table: "Disbursements",
+          column: "CharityId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Disbursements_Status",
-                table: "Disbursements",
-                column: "Status");
+      migrationBuilder.CreateIndex(
+          name: "IX_Disbursements_Status",
+          table: "Disbursements",
+          column: "Status");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_Penalties_Disbursements_DisbursementId",
-                table: "Penalties",
-                column: "DisbursementId",
-                principalTable: "Disbursements",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.SetNull);
-        }
-
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropForeignKey(
-                name: "FK_Penalties_Disbursements_DisbursementId",
-                table: "Penalties");
-
-            migrationBuilder.DropTable(
-                name: "Disbursements");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Penalties_DisbursementId",
-                table: "Penalties");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Penalties_Status_DisbursementId",
-                table: "Penalties");
-
-            migrationBuilder.DropColumn(
-                name: "DisbursementId",
-                table: "Penalties");
-        }
+      migrationBuilder.AddForeignKey(
+          name: "FK_Penalties_Disbursements_DisbursementId",
+          table: "Penalties",
+          column: "DisbursementId",
+          principalTable: "Disbursements",
+          principalColumn: "Id",
+          onDelete: ReferentialAction.SetNull);
     }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+      migrationBuilder.DropForeignKey(
+          name: "FK_Penalties_Disbursements_DisbursementId",
+          table: "Penalties");
+
+      migrationBuilder.DropTable(
+          name: "Disbursements");
+
+      migrationBuilder.DropIndex(
+          name: "IX_Penalties_DisbursementId",
+          table: "Penalties");
+
+      migrationBuilder.DropIndex(
+          name: "IX_Penalties_Status_DisbursementId",
+          table: "Penalties");
+
+      migrationBuilder.DropColumn(
+          name: "DisbursementId",
+          table: "Penalties");
+    }
+  }
 }

--- a/App/Modules/Charities/Sync/IPledgeClient.cs
+++ b/App/Modules/Charities/Sync/IPledgeClient.cs
@@ -6,4 +6,13 @@ public interface IPledgeClient
 {
   Task<Result<IEnumerable<PledgeCauseDto>>> GetCauses(CancellationToken ct = default);
   Task<Result<PledgeOrganizationsPage>> GetOrganizations(int page, int perPage, string? causeKey = null, string[]? countries = null, DateTimeOffset? updatedSince = null, CancellationToken ct = default);
+
+  // POST /v1/donations — record a donation to a nonprofit (Pledge batches & bills our payment
+  // method on file). A 4xx/5xx is surfaced as a failed Result (not thrown) so the caller can
+  // record it and retry rather than aborting the batch.
+  Task<Result<PledgeDonationDto>> CreateDonation(PledgeDonationReq req, CancellationToken ct = default);
+
+  // GET /v1/donations — one page of donations made through our account, newest first. Used by
+  // reconciliation to find a donation by the metadata we stamped on it.
+  Task<Result<PledgeDonationsPage>> GetDonations(int page, CancellationToken ct = default);
 }

--- a/App/Modules/Charities/Sync/PledgeClient.cs
+++ b/App/Modules/Charities/Sync/PledgeClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Json;
 using App.Error.V1;
 using App.StartUp.Registry;
 using App.Utility;
@@ -63,6 +64,66 @@ namespace App.Modules.Charities.Sync;
     catch (Exception e)
     {
       logger.LogError(e, "Failed to fetch Pledge organizations page {Page} for cause {Cause}", page, causeKey ?? "all");
+      throw;
+    }
+  }
+
+  public async Task<Result<PledgeDonationDto>> CreateDonation(PledgeDonationReq req, CancellationToken ct = default)
+  {
+    try
+    {
+      if (this.Client.BaseAddress == null)
+      {
+        logger.LogWarning("Pledge HttpClient is not configured (BaseAddress missing)");
+        return new ValidationError("Pledge HttpClient not configured",
+          new Dictionary<string, string[]> { ["httpClient"] = [HttpClients.Pledge] }).ToException();
+      }
+
+      using var response = await this.Client.PostAsJsonAsync("v1/donations", req, ct);
+      var body = await response.Content.ReadAsStringAsync(ct);
+      if (!response.IsSuccessStatusCode)
+      {
+        // 4xx/5xx -> failed Result (not thrown). The caller records it and retries; one bad
+        // donation must not abort the payout batch.
+        logger.LogError("Pledge CreateDonation failed: {Status} org={Org} body={Body}",
+          (int)response.StatusCode, req.OrganizationId, body);
+        return new ValidationError($"Pledge donation failed with status {(int)response.StatusCode}",
+          new Dictionary<string, string[]> { ["pledge"] = [body] }).ToException();
+      }
+
+      var dto = body.ToObj<PledgeDonationDto>();
+      if (dto == null || string.IsNullOrWhiteSpace(dto.Id))
+      {
+        logger.LogError("Pledge CreateDonation returned an unparseable/empty body: {Body}", body);
+        return new ValidationError("Pledge donation response missing id",
+          new Dictionary<string, string[]> { ["pledge"] = [body] }).ToException();
+      }
+      logger.LogInformation("Pledge donation created: {DonationId} (status {Status}) for org {Org}", dto.Id, dto.Status, req.OrganizationId);
+      return dto;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to create Pledge donation for org {Org}", req.OrganizationId);
+      throw;
+    }
+  }
+
+  public async Task<Result<PledgeDonationsPage>> GetDonations(int page, CancellationToken ct = default)
+  {
+    try
+    {
+      if (this.Client.BaseAddress == null)
+      {
+        logger.LogWarning("Pledge HttpClient is not configured (BaseAddress missing)");
+        return new ValidationError("Pledge HttpClient not configured",
+          new Dictionary<string, string[]> { ["httpClient"] = [HttpClients.Pledge] }).ToException();
+      }
+      var res = await this.Client.GetFromJsonAsync<PledgeDonationsPage>($"v1/donations?page={page}", cancellationToken: ct);
+      return res ?? new PledgeDonationsPage { Results = [], Page = page };
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to fetch Pledge donations page {Page}", page);
       throw;
     }
   }

--- a/App/Modules/Charities/Sync/PledgeClient.cs
+++ b/App/Modules/Charities/Sync/PledgeClient.cs
@@ -3,10 +3,11 @@ using App.Error.V1;
 using App.StartUp.Registry;
 using App.Utility;
 using CSharp_Result;
+using Domain.Disbursement;
 
 namespace App.Modules.Charities.Sync;
 
-  public class PledgeClient(IHttpClientFactory httpClientFactory, ILogger<PledgeClient> logger) : IPledgeClient
+public class PledgeClient(IHttpClientFactory httpClientFactory, ILogger<PledgeClient> logger) : IPledgeClient
 {
   private HttpClient Client => httpClientFactory.CreateClient(HttpClients.Pledge);
 
@@ -80,23 +81,35 @@ namespace App.Modules.Charities.Sync;
       }
 
       using var response = await this.Client.PostAsJsonAsync("v1/donations", req, ct);
-      var body = await response.Content.ReadAsStringAsync(ct);
+      var status = (int)response.StatusCode;
       if (!response.IsSuccessStatusCode)
       {
-        // 4xx/5xx -> failed Result (not thrown). The caller records it and retries; one bad
-        // donation must not abort the payout batch.
-        logger.LogError("Pledge CreateDonation failed: {Status} org={Org} body={Body}",
-          (int)response.StatusCode, req.OrganizationId, body);
-        return new ValidationError($"Pledge donation failed with status {(int)response.StatusCode}",
-          new Dictionary<string, string[]> { ["pledge"] = [body] }).ToException();
+        // Do NOT log or surface the response body: this request carries the donor's name/email and
+        // provider validation errors echo that input, so the body is PII and must not land in logs
+        // or the (durable) LastError column. Log the status only.
+        // 4xx => the provider refused the request and created NOTHING, so it is safe to release the
+        // penalties for retry (DonationRejectedException). 5xx => the donation MAY have been created
+        // before the error, so this is AMBIGUOUS: return a plain failure and let the caller keep the
+        // disbursement Pending for reconciliation rather than risk a double payout.
+        if (status is >= 400 and < 500)
+        {
+          logger.LogWarning("Pledge CreateDonation rejected (status {Status}) for org {Org}", status, req.OrganizationId);
+          return new DonationRejectedException($"Pledge donation rejected with status {status}");
+        }
+        logger.LogError("Pledge CreateDonation failed (status {Status}, ambiguous) for org {Org}", status, req.OrganizationId);
+        return new ValidationError($"Pledge donation failed with status {status}",
+          new Dictionary<string, string[]> { ["pledge"] = [$"status {status}"] }).ToException();
       }
 
+      var body = await response.Content.ReadAsStringAsync(ct);
       var dto = body.ToObj<PledgeDonationDto>();
       if (dto == null || string.IsNullOrWhiteSpace(dto.Id))
       {
-        logger.LogError("Pledge CreateDonation returned an unparseable/empty body: {Body}", body);
+        // 2xx but no usable id: we cannot confirm the donation id, yet it may have been created.
+        // Treat as ambiguous (not a rejection) so reconciliation settles it by metadata.
+        logger.LogError("Pledge CreateDonation returned {Status} with no usable donation id for org {Org}", status, req.OrganizationId);
         return new ValidationError("Pledge donation response missing id",
-          new Dictionary<string, string[]> { ["pledge"] = [body] }).ToException();
+          new Dictionary<string, string[]> { ["pledge"] = ["missing id"] }).ToException();
       }
       logger.LogInformation("Pledge donation created: {DonationId} (status {Status}) for org {Org}", dto.Id, dto.Status, req.OrganizationId);
       return dto;
@@ -119,7 +132,13 @@ namespace App.Modules.Charities.Sync;
           new Dictionary<string, string[]> { ["httpClient"] = [HttpClients.Pledge] }).ToException();
       }
       var res = await this.Client.GetFromJsonAsync<PledgeDonationsPage>($"v1/donations?page={page}", cancellationToken: ct);
-      return res ?? new PledgeDonationsPage { Results = [], Page = page };
+      // A null body is an unknown vendor state, NOT an empty page. Returning an empty page here
+      // would let reconciliation read "no such donation" and release penalties for re-donation;
+      // surface a failure so the caller treats the lookup as inconclusive and keeps it Pending.
+      if (res == null)
+        return new ValidationError("Pledge donations response was empty",
+          new Dictionary<string, string[]> { ["pledge"] = ["null body"] }).ToException();
+      return res;
     }
     catch (Exception e)
     {

--- a/App/Modules/Charities/Sync/PledgeModels.cs
+++ b/App/Modules/Charities/Sync/PledgeModels.cs
@@ -55,3 +55,35 @@ public record PledgeOrganizationsPage
   [JsonPropertyName("previous")] public string? PreviousUri { get; init; }
   [JsonPropertyName("results")] public PledgeOrganizationDto[] Data { get; init; } = [];
 }
+
+// POST /v1/donations request body. email/first_name/last_name/amount/organization_id are
+// required by Pledge; `amount` is a STRING DECIMAL in major units (e.g. "5.00"), and there is
+// no currency field (Pledge donations bill the account's payment method on file). `metadata` is
+// a free-form string — we store our Disbursement.Id there so a crashed attempt can be looked up.
+public record PledgeDonationReq
+{
+  [JsonPropertyName("email")] public required string Email { get; init; }
+  [JsonPropertyName("first_name")] public required string FirstName { get; init; }
+  [JsonPropertyName("last_name")] public required string LastName { get; init; }
+  [JsonPropertyName("amount")] public required string Amount { get; init; }
+  [JsonPropertyName("organization_id")] public required string OrganizationId { get; init; }
+  [JsonPropertyName("metadata")] public string? Metadata { get; init; }
+}
+
+public record PledgeDonationDto
+{
+  [JsonPropertyName("id")] public string Id { get; init; } = string.Empty;
+  [JsonPropertyName("status")] public string Status { get; init; } = string.Empty;
+  [JsonPropertyName("metadata")] public string? Metadata { get; init; }
+  [JsonPropertyName("amount")] public string Amount { get; init; } = string.Empty;
+  [JsonPropertyName("organization_id")] public string OrganizationId { get; init; } = string.Empty;
+}
+
+public record PledgeDonationsPage
+{
+  [JsonPropertyName("page")] public int Page { get; init; }
+  [JsonPropertyName("per")] public int PerPage { get; init; }
+  [JsonPropertyName("total_count")] public int TotalCount { get; init; }
+  [JsonPropertyName("next")] public string? NextUri { get; init; }
+  [JsonPropertyName("results")] public PledgeDonationDto[] Results { get; init; } = [];
+}

--- a/App/Modules/Disbursement/API/V1/DisbursementController.cs
+++ b/App/Modules/Disbursement/API/V1/DisbursementController.cs
@@ -1,0 +1,44 @@
+using System.Net.Mime;
+using App.Modules.Common;
+using App.StartUp.Options;
+using App.StartUp.Registry;
+using App.StartUp.Services.Auth;
+using Asp.Versioning;
+using CSharp_Result;
+using Domain.Disbursement;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace App.Modules.Disbursement.API.V1;
+
+// Admin-only manual trigger for the charity payout pass. The worker normally runs on a daily
+// timer; this endpoint runs one pass on demand (reconcile + claim + donate) using the configured
+// donor + thresholds — used for ops and end-to-end testing against the Pledge sandbox.
+[ApiVersion(1.0)]
+[ApiController]
+[Consumes(MediaTypeNames.Application.Json)]
+[Route("api/v{version:apiVersion}/disbursement")]
+[Authorize(Policy = AuthPolicies.OnlyAdmin)]
+public class DisbursementController(
+  IDisbursementService service,
+  IOptionsMonitor<DisbursementOption> options,
+  IAuthHelper h) : AtomiControllerBase(h)
+{
+  public record RunDisbursementRes(int Completed);
+
+  [HttpPost("run")]
+  public async Task<ActionResult<RunDisbursementRes>> Run()
+  {
+    var opt = options.CurrentValue;
+    var donor = new DonorIdentity
+    {
+      FirstName = opt.DonorFirstName,
+      LastName = opt.DonorLastName,
+      Email = opt.DonorEmail
+    };
+    var r = await service.ProcessPending(donor, opt.MinPayoutCents, opt.MaxGroupsPerRun)
+      .Then(count => new RunDisbursementRes(count), Errors.MapNone);
+    return this.ReturnResult(r);
+  }
+}

--- a/App/Modules/Disbursement/Data/DisbursementData.cs
+++ b/App/Modules/Disbursement/Data/DisbursementData.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using App.Modules.Charities.Data;
+
+namespace App.Modules.Disbursement.Data;
+
+// One row per payout attempt to a single (charity, currency). The Id doubles as the
+// idempotency key sent to Pledge so a crash-and-retry reconciles the same donation
+// instead of minting a second one (mirrors the penalty PaymentIntentId reconcile).
+public class DisbursementData
+{
+  [Key]
+  public Guid Id { get; set; }
+  public required Guid CharityId { get; set; }
+  [MaxLength(8)]
+  public required string Currency { get; set; }
+  public long AmountCents { get; set; } // long: a payout sums many penalties
+  public required int Status { get; set; } // store DisbursementStatus as int
+  // PledgeOrganizationId is captured at claim time so a reconcile pass can re-issue the
+  // donation with the SAME idempotency key without re-resolving the charity's external id.
+  [MaxLength(256)]
+  public required string PledgeOrganizationId { get; set; }
+  [MaxLength(256)]
+  public string? ProviderDonationId { get; set; } // Pledge donation id, set on success
+  public int Attempts { get; set; } = 0;
+  [MaxLength(2048)]
+  public string? LastError { get; set; }
+  public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+  public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+  public virtual CharityData? Charity { get; set; }
+}

--- a/App/Modules/Disbursement/Data/DisbursementMapper.cs
+++ b/App/Modules/Disbursement/Data/DisbursementMapper.cs
@@ -1,0 +1,27 @@
+using Domain.Disbursement;
+using NodaMoney;
+
+namespace App.Modules.Disbursement.Data;
+
+public static class DisbursementMapper
+{
+  public static DisbursementPrincipal ToPrincipal(this DisbursementData data)
+  {
+    return new DisbursementPrincipal
+    {
+      Id = data.Id,
+      Record = new DisbursementRecord
+      {
+        CharityId = data.CharityId,
+        Amount = new Money(data.AmountCents / 100m, Currency.FromCode(data.Currency)),
+        PledgeOrganizationId = data.PledgeOrganizationId,
+        Status = (DisbursementStatus)data.Status,
+        ProviderDonationId = data.ProviderDonationId,
+        Attempts = data.Attempts,
+        LastError = data.LastError
+      },
+      CreatedAt = data.CreatedAt,
+      UpdatedAt = data.UpdatedAt
+    };
+  }
+}

--- a/App/Modules/Disbursement/Data/DisbursementMapper.cs
+++ b/App/Modules/Disbursement/Data/DisbursementMapper.cs
@@ -5,23 +5,30 @@ namespace App.Modules.Disbursement.Data;
 
 public static class DisbursementMapper
 {
+  // Data => Domain (reuse chain): ToRecord -> ToPrincipal -> ToDomain, each building on the last.
+  public static DisbursementRecord ToRecord(this DisbursementData data)
+    => new()
+    {
+      CharityId = data.CharityId,
+      Amount = new Money(data.AmountCents / 100m, Currency.FromCode(data.Currency)),
+      PledgeOrganizationId = data.PledgeOrganizationId,
+      Status = (DisbursementStatus)data.Status,
+      ProviderDonationId = data.ProviderDonationId,
+      Attempts = data.Attempts,
+      LastError = data.LastError
+    };
+
   public static DisbursementPrincipal ToPrincipal(this DisbursementData data)
-  {
-    return new DisbursementPrincipal
+    => new()
     {
       Id = data.Id,
-      Record = new DisbursementRecord
-      {
-        CharityId = data.CharityId,
-        Amount = new Money(data.AmountCents / 100m, Currency.FromCode(data.Currency)),
-        PledgeOrganizationId = data.PledgeOrganizationId,
-        Status = (DisbursementStatus)data.Status,
-        ProviderDonationId = data.ProviderDonationId,
-        Attempts = data.Attempts,
-        LastError = data.LastError
-      },
+      Record = data.ToRecord(),
       CreatedAt = data.CreatedAt,
       UpdatedAt = data.UpdatedAt
     };
-  }
+
+  // Fully qualified: the aggregate type `Disbursement` would otherwise bind to the
+  // `App.Modules.Disbursement` namespace from inside this file.
+  public static Domain.Disbursement.Disbursement ToDomain(this DisbursementData data)
+    => new() { Principal = data.ToPrincipal() };
 }

--- a/App/Modules/Disbursement/Data/DisbursementRepository.cs
+++ b/App/Modules/Disbursement/Data/DisbursementRepository.cs
@@ -1,0 +1,221 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Disbursement;
+using Domain.Penalty;
+using Microsoft.EntityFrameworkCore;
+using NodaMoney;
+
+namespace App.Modules.Disbursement.Data;
+
+public class DisbursementRepository(MainDbContext db, ILogger<DisbursementRepository> logger) : IDisbursementRepository
+{
+  private const string PledgeSource = "pledge";
+
+  public async Task<Result<List<ClaimedPayout>>> ClaimPendingPayouts(long minPayoutCents, int maxGroups)
+  {
+    try
+    {
+      await using var tx = await db.Database.BeginTransactionAsync();
+
+      // Lock the charged-but-unpaid penalty rows for this pass. FOR UPDATE SKIP LOCKED holds the
+      // locks until commit, so a concurrent claim cannot grab the same rows and double-donate;
+      // the stamping below (DisbursementId set) is what keeps them excluded on later passes.
+      // ToListAsync (not FirstOrDefault) so EF runs the raw SQL verbatim without wrapping the
+      // FOR UPDATE in an unsupported subquery.
+      var candidates = await db.Penalties
+        .FromSqlRaw(@"
+          SELECT * FROM ""Penalties""
+          WHERE ""Status"" = {0} AND ""DisbursementId"" IS NULL
+          ORDER BY ""CreatedAt""
+          FOR UPDATE SKIP LOCKED",
+          (int)PenaltyStatus.Charged)
+        .ToListAsync();
+
+      // Group by (charity, currency): one donation per pair, never summing across currencies.
+      var groups = candidates
+        .GroupBy(p => (p.CharityId, p.Currency))
+        .Select(g => new
+        {
+          g.Key.CharityId,
+          g.Key.Currency,
+          Sum = g.Sum(x => (long)x.AmountCents),
+          Ids = g.Select(x => x.Id).ToList()
+        })
+        .Where(g => g.Sum >= minPayoutCents)
+        .OrderByDescending(g => g.Sum)
+        .ToList();
+
+      if (groups.Count == 0)
+      {
+        await tx.RollbackAsync();
+        return new List<ClaimedPayout>();
+      }
+
+      // Resolve each charity's Pledge org id (the donation target). A charity could in principle
+      // carry more than one pledge link; take the first deterministically.
+      var charityIds = groups.Select(g => g.CharityId).Distinct().ToList();
+      var orgRows = await db.ExternalIds.AsNoTracking()
+        .Where(e => e.Source == PledgeSource && charityIds.Contains(e.CharityId))
+        .ToListAsync();
+      var orgIdByCharity = orgRows
+        .GroupBy(e => e.CharityId)
+        .ToDictionary(g => g.Key, g => g.First().ExternalKey);
+
+      var now = DateTime.UtcNow;
+      var claimed = new List<ClaimedPayout>();
+      foreach (var g in groups)
+      {
+        if (claimed.Count >= maxGroups) break;
+        if (!orgIdByCharity.TryGetValue(g.CharityId, out var orgId) || string.IsNullOrWhiteSpace(orgId))
+        {
+          // No Pledge org id -> we cannot donate. Leave the penalties unclaimed (pending payout)
+          // so they settle once the charity is (re)synced and gets an org id.
+          logger.LogWarning("Skipping payout for charity {CharityId} ({Currency}): no Pledge org id", g.CharityId, g.Currency);
+          continue;
+        }
+
+        var d = new DisbursementData
+        {
+          Id = Guid.NewGuid(), // generated up front: it is both the FK we stamp and the vendor reference
+          CharityId = g.CharityId,
+          Currency = g.Currency,
+          AmountCents = g.Sum,
+          Status = (int)DisbursementStatus.Pending,
+          PledgeOrganizationId = orgId,
+          Attempts = 0,
+          CreatedAt = now,
+          UpdatedAt = now
+        };
+        db.Disbursements.Add(d);
+        // Insert the disbursement BEFORE stamping penalties: the penalties' DisbursementId FK
+        // references this row, and ExecuteUpdate runs immediately (the row must already exist).
+        await db.SaveChangesAsync();
+
+        await db.Penalties
+          .Where(p => g.Ids.Contains(p.Id))
+          .ExecuteUpdateAsync(s => s
+            .SetProperty(p => p.DisbursementId, d.Id)
+            .SetProperty(p => p.UpdatedAt, now));
+
+        claimed.Add(new ClaimedPayout
+        {
+          DisbursementId = d.Id,
+          CharityId = g.CharityId,
+          PledgeOrganizationId = orgId,
+          Amount = new Money(g.Sum / 100m, Currency.FromCode(g.Currency))
+        });
+      }
+
+      await tx.CommitAsync();
+      return claimed;
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "ClaimPendingPayouts failed for MinPayoutCents={Min} MaxGroups={Max}", minPayoutCents, maxGroups);
+      throw;
+    }
+  }
+
+  public async Task<Result<Unit>> MarkDisbursed(Guid disbursementId, string providerDonationId)
+  {
+    try
+    {
+      await using var tx = await db.Database.BeginTransactionAsync();
+
+      // Lock the disbursement row so a reconcile racing the original donate serializes here:
+      // the second waits, then sees Completed and no-ops instead of overwriting the donation id.
+      var d = (await db.Disbursements
+          .FromSqlRaw(@"SELECT * FROM ""Disbursements"" WHERE ""Id"" = {0} FOR UPDATE", disbursementId)
+          .ToListAsync())
+        .FirstOrDefault();
+      if (d == null)
+      {
+        await tx.RollbackAsync();
+        return new Unit();
+      }
+      if (d.Status == (int)DisbursementStatus.Completed)
+      {
+        // Already settled; idempotent no-op.
+        await tx.RollbackAsync();
+        return new Unit();
+      }
+
+      d.Status = (int)DisbursementStatus.Completed;
+      d.ProviderDonationId = providerDonationId;
+      d.LastError = null;
+      d.UpdatedAt = DateTime.UtcNow;
+      await db.SaveChangesAsync();
+      await tx.CommitAsync();
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "MarkDisbursed failed for Id={Id} ProviderDonationId={ProviderDonationId}", disbursementId, providerDonationId);
+      throw;
+    }
+  }
+
+  public async Task<Result<Unit>> MarkFailed(Guid disbursementId, string error)
+  {
+    try
+    {
+      await using var tx = await db.Database.BeginTransactionAsync();
+
+      var d = (await db.Disbursements
+          .FromSqlRaw(@"SELECT * FROM ""Disbursements"" WHERE ""Id"" = {0} FOR UPDATE", disbursementId)
+          .ToListAsync())
+        .FirstOrDefault();
+      if (d == null)
+      {
+        await tx.RollbackAsync();
+        return new Unit();
+      }
+      if (d.Status == (int)DisbursementStatus.Completed)
+      {
+        // A donation that already settled must never be undone/released.
+        await tx.RollbackAsync();
+        return new Unit();
+      }
+
+      d.Status = (int)DisbursementStatus.Failed;
+      d.LastError = error;
+      d.Attempts += 1;
+      d.UpdatedAt = DateTime.UtcNow;
+
+      // Release the claimed penalties so a later pass re-claims them into a fresh disbursement.
+      await db.Penalties
+        .Where(p => p.DisbursementId == disbursementId)
+        .ExecuteUpdateAsync(s => s
+          .SetProperty(p => p.DisbursementId, (Guid?)null)
+          .SetProperty(p => p.UpdatedAt, DateTime.UtcNow));
+
+      await db.SaveChangesAsync();
+      await tx.CommitAsync();
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "MarkFailed failed for Id={Id}", disbursementId);
+      throw;
+    }
+  }
+
+  public async Task<Result<List<DisbursementPrincipal>>> GetReconcilable(TimeSpan olderThan, int batchSize)
+  {
+    try
+    {
+      var cutoff = DateTime.UtcNow - olderThan;
+      var rows = await db.Disbursements.AsNoTracking()
+        .Where(d => d.Status == (int)DisbursementStatus.Pending && d.UpdatedAt < cutoff)
+        .OrderBy(d => d.UpdatedAt)
+        .Take(batchSize)
+        .ToListAsync();
+      return rows.Select(x => x.ToPrincipal()).ToList();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "GetReconcilable failed");
+      throw;
+    }
+  }
+}

--- a/App/Modules/Disbursement/Data/DisbursementRepository.cs
+++ b/App/Modules/Disbursement/Data/DisbursementRepository.cs
@@ -52,14 +52,18 @@ public class DisbursementRepository(MainDbContext db, ILogger<DisbursementReposi
       }
 
       // Resolve each charity's Pledge org id (the donation target). A charity could in principle
-      // carry more than one pledge link; take the first deterministically.
+      // carry more than one pledge link. Pick deterministically (most recently synced, then a
+      // stable tie-break on the key) — an unordered First() could send the payout to a different
+      // organization across runs.
       var charityIds = groups.Select(g => g.CharityId).Distinct().ToList();
       var orgRows = await db.ExternalIds.AsNoTracking()
         .Where(e => e.Source == PledgeSource && charityIds.Contains(e.CharityId))
         .ToListAsync();
       var orgIdByCharity = orgRows
         .GroupBy(e => e.CharityId)
-        .ToDictionary(g => g.Key, g => g.First().ExternalKey);
+        .ToDictionary(
+          g => g.Key,
+          g => g.OrderByDescending(e => e.LastSyncedAt).ThenBy(e => e.ExternalKey, StringComparer.Ordinal).First().ExternalKey);
 
       var now = DateTime.UtcNow;
       var claimed = new List<ClaimedPayout>();

--- a/App/Modules/Disbursement/DisbursementHostedService.cs
+++ b/App/Modules/Disbursement/DisbursementHostedService.cs
@@ -1,0 +1,82 @@
+using App.StartUp.Options;
+using Domain.Disbursement;
+using Microsoft.Extensions.Options;
+
+namespace App.Modules.Disbursement;
+
+// Scheduled charity payout. Once a day it reconciles any in-flight disbursements, then claims the
+// charged-but-unpaid penalties grouped by (charity, currency) and donates each via Pledge. The
+// atomic claim (DisbursementId stamped under a row lock) prevents double-donation across passes;
+// this in-process gate just avoids overlapping work.
+public class DisbursementHostedService(
+  IServiceProvider serviceProvider,
+  IOptionsMonitor<DisbursementOption> options,
+  ILogger<DisbursementHostedService> logger
+) : IHostedService, IDisposable
+{
+  private Timer? _timer;
+  private readonly SemaphoreSlim _gate = new(1, 1);
+
+  public Task StartAsync(CancellationToken cancellationToken)
+  {
+    if (!options.CurrentValue.Enabled)
+    {
+      logger.LogInformation("DisbursementHostedService disabled (Disbursement.Enabled=false); not scheduling");
+      return Task.CompletedTask;
+    }
+
+    // Daily payout. The longer startup delay lets the penalty drain settle the day's charges
+    // (which is what creates pending payouts) before we sweep them.
+    _timer = new Timer(async _ => await DoWork(), null, TimeSpan.FromMinutes(5), TimeSpan.FromHours(24));
+    logger.LogInformation("DisbursementHostedService started");
+    return Task.CompletedTask;
+  }
+
+  private async Task DoWork()
+  {
+    if (!await _gate.WaitAsync(0))
+    {
+      logger.LogInformation("Disbursement previous pass still running; skipping tick");
+      return;
+    }
+    try
+    {
+      var opt = options.CurrentValue;
+      var donor = new DonorIdentity
+      {
+        FirstName = opt.DonorFirstName,
+        LastName = opt.DonorLastName,
+        Email = opt.DonorEmail
+      };
+
+      using var scope = serviceProvider.CreateScope();
+      var svc = scope.ServiceProvider.GetRequiredService<IDisbursementService>();
+      var res = await svc.ProcessPending(donor, opt.MinPayoutCents, opt.MaxGroupsPerRun);
+      if (res.IsSuccess())
+        logger.LogInformation("Disbursement paid out {Count} group(s)", (int)res);
+      else
+        logger.LogError(res.FailureOrDefault(), "Disbursement error");
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "DisbursementHostedService failed");
+    }
+    finally
+    {
+      _gate.Release();
+    }
+  }
+
+  public Task StopAsync(CancellationToken cancellationToken)
+  {
+    _timer?.Change(Timeout.Infinite, 0);
+    logger.LogInformation("DisbursementHostedService stopping");
+    return Task.CompletedTask;
+  }
+
+  public void Dispose()
+  {
+    _timer?.Dispose();
+    _gate.Dispose();
+  }
+}

--- a/App/Modules/Disbursement/PledgeDonationGateway.cs
+++ b/App/Modules/Disbursement/PledgeDonationGateway.cs
@@ -31,6 +31,11 @@ public class PledgeDonationGateway(IPledgeClient pledge, ILogger<PledgeDonationG
       .Then(dto => new DonationResult { DonationId = dto.Id, Status = dto.Status }, Errors.MapNone);
   }
 
+  // Returns the matching donation if found; null ONLY when the scan conclusively reached the end
+  // without a match; and a FAILURE when the lookup is inconclusive (a page fetch failed, or we hit
+  // the page cap with more pages still unscanned). The distinction matters: the caller releases the
+  // penalties on a conclusive null but must keep the disbursement Pending on a failure, so an
+  // inconclusive lookup never causes a re-donation.
   public async Task<Result<DonationResult?>> FindDonationByReference(string reference)
   {
     for (var page = 1; page <= MaxReconcilePages; page++)
@@ -39,7 +44,8 @@ public class PledgeDonationGateway(IPledgeClient pledge, ILogger<PledgeDonationG
       if (pageRes.IsFailure()) return pageRes.FailureOrDefault()!;
 
       var data = pageRes.SuccessOrDefault();
-      if (data == null || data.Results.Length == 0) break;
+      if (data == null || data.Results.Length == 0)
+        return (DonationResult?)null; // reached the end with no match
 
       var match = data.Results.FirstOrDefault(d => string.Equals(d.Metadata, reference, StringComparison.Ordinal));
       if (match != null)
@@ -48,8 +54,14 @@ public class PledgeDonationGateway(IPledgeClient pledge, ILogger<PledgeDonationG
         return new DonationResult { DonationId = match.Id, Status = match.Status };
       }
 
-      if (string.IsNullOrEmpty(data.NextUri)) break; // last page
+      if (string.IsNullOrEmpty(data.NextUri))
+        return (DonationResult?)null; // last page, conclusively not found
     }
-    return (DonationResult?)null;
+
+    // Hit the page cap with more pages remaining: we did NOT scan to the end, so we cannot say the
+    // donation is absent. Inconclusive -> failure, so the caller leaves the disbursement Pending.
+    logger.LogWarning("Reconcile for reference {Reference} hit the {Cap}-page cap without reaching the end; inconclusive", reference, MaxReconcilePages);
+    return new InvalidOperationException(
+      $"Reconcile lookup for {reference} exceeded {MaxReconcilePages} pages without conclusion");
   }
 }

--- a/App/Modules/Disbursement/PledgeDonationGateway.cs
+++ b/App/Modules/Disbursement/PledgeDonationGateway.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using App.Modules.Charities.Sync;
+using CSharp_Result;
+using Domain.Disbursement;
+
+namespace App.Modules.Disbursement;
+
+// App-side implementation of the domain donation port over the Pledge HTTP client. Maps the
+// vendor-agnostic DonationRequest to Pledge's body (amount as a decimal string, our reference
+// stored in `metadata`) and reconciles by scanning donations for that metadata.
+public class PledgeDonationGateway(IPledgeClient pledge, ILogger<PledgeDonationGateway> logger) : IDonationGateway
+{
+  // How many donation pages to scan when reconciling. The daily batch volume is small, so the
+  // donation we are looking for (if it landed) sits within the first few pages (newest first).
+  private const int MaxReconcilePages = 20;
+
+  public async Task<Result<DonationResult>> CreateDonation(DonationRequest req)
+  {
+    var body = new PledgeDonationReq
+    {
+      Email = req.DonorEmail,
+      FirstName = req.DonorFirstName,
+      LastName = req.DonorLastName,
+      // Pledge expects a decimal string in major units (e.g. "5.00"); there is no currency field.
+      Amount = req.Amount.Amount.ToString("0.00", CultureInfo.InvariantCulture),
+      OrganizationId = req.OrganizationId,
+      Metadata = req.Reference // our Disbursement.Id — the correlation key for reconciliation
+    };
+
+    return await pledge.CreateDonation(body)
+      .Then(dto => new DonationResult { DonationId = dto.Id, Status = dto.Status }, Errors.MapNone);
+  }
+
+  public async Task<Result<DonationResult?>> FindDonationByReference(string reference)
+  {
+    for (var page = 1; page <= MaxReconcilePages; page++)
+    {
+      var pageRes = await pledge.GetDonations(page);
+      if (pageRes.IsFailure()) return pageRes.FailureOrDefault()!;
+
+      var data = pageRes.SuccessOrDefault();
+      if (data == null || data.Results.Length == 0) break;
+
+      var match = data.Results.FirstOrDefault(d => string.Equals(d.Metadata, reference, StringComparison.Ordinal));
+      if (match != null)
+      {
+        logger.LogInformation("Reconcile matched donation {DonationId} for reference {Reference}", match.Id, reference);
+        return new DonationResult { DonationId = match.Id, Status = match.Status };
+      }
+
+      if (string.IsNullOrEmpty(data.NextUri)) break; // last page
+    }
+    return (DonationResult?)null;
+  }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -20,6 +20,7 @@ using Domain.Allowance;
 using Domain.Cause;
 using Domain.Charity;
 using Domain.Configuration;
+using Domain.Disbursement;
 using Domain.Entitlement;
 using Domain.Habit;
 using Domain.Payment;
@@ -136,6 +137,14 @@ public static class DomainServices
       .AutoTrace<IPledgeClient>();
     s.AddScoped<IPledgeSyncService, PledgeSyncService>()
       .AutoTrace<IPledgeSyncService>();
+
+    // DISBURSEMENT (charity payout)
+    s.AddScoped<IDisbursementService, Domain.Disbursement.DisbursementService>()
+      .AutoTrace<IDisbursementService>();
+    s.AddScoped<IDisbursementRepository, App.Modules.Disbursement.Data.DisbursementRepository>()
+      .AutoTrace<IDisbursementRepository>();
+    s.AddScoped<IDonationGateway, App.Modules.Disbursement.PledgeDonationGateway>()
+      .AutoTrace<IDonationGateway>();
 
 
 

--- a/App/Modules/Penalty/Data/PenaltyData.cs
+++ b/App/Modules/Penalty/Data/PenaltyData.cs
@@ -22,6 +22,12 @@ public class PenaltyData
   public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
   public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
+  // Payout linkage: NULL while Status=Charged means "pending payout"; set means the
+  // penalty has been claimed by (and, once that disbursement Completes, paid out via)
+  // the referenced Disbursement. Stamped at claim time so concurrent/retried payout
+  // passes never re-select the same charged penalty and double-donate.
+  public Guid? DisbursementId { get; set; }
+
   // Foreign Keys & Navigation
   [MaxLength(128)]
   public required string UserId { get; set; }

--- a/App/Modules/Penalty/Data/PenaltyMapper.cs
+++ b/App/Modules/Penalty/Data/PenaltyMapper.cs
@@ -34,7 +34,8 @@ public static class PenaltyMapper
       Status = (PenaltyStatus)data.Status,
       PaymentIntentId = data.PaymentIntentId,
       Attempts = data.Attempts,
-      LastError = data.LastError
+      LastError = data.LastError,
+      DisbursementId = data.DisbursementId
     };
   }
 

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -1,6 +1,7 @@
 using App.Modules.Causes.Data;
 using App.Modules.Charities.Data;
 using App.Modules.Configurations.Data;
+using App.Modules.Disbursement.Data;
 using App.Modules.Habit.Data;
 using App.Modules.HabitExecution.Data;
 using App.Modules.HabitVersion.Data;
@@ -41,6 +42,8 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
   // Penalty
   public DbSet<PenaltyData> Penalties { get; set; }
   public DbSet<CharityBalanceData> CharityBalances { get; set; }
+  // Disbursement (charity payout)
+  public DbSet<DisbursementData> Disbursements { get; set; }
   // public DbSet<CompletionData> Completions { get; set; }
   // public DbSet<StatsData> Stats { get; set; }
 
@@ -137,10 +140,25 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
     var penalty = modelBuilder.Entity<PenaltyData>();
     penalty.HasIndex(x => x.HabitExecutionId).IsUnique();   // exactly-once per execution
     penalty.HasIndex(x => new { x.Status, x.Attempts });    // drain query: GetPending
+    penalty.HasIndex(x => new { x.Status, x.DisbursementId }); // pending-payout scan: Charged + DisbursementId IS NULL
     penalty.HasOne(x => x.Charity)
            .WithMany()
            .HasForeignKey(x => x.CharityId)
            .OnDelete(DeleteBehavior.Cascade);
+    // Payout linkage. SetNull (not Cascade): deleting a disbursement row must never
+    // delete the underlying penalties — it just releases them back to pending-payout.
+    penalty.HasOne<DisbursementData>()
+           .WithMany()
+           .HasForeignKey(x => x.DisbursementId)
+           .OnDelete(DeleteBehavior.SetNull);
+
+    // Disbursement (charity payout ledger): one row per (charity, currency) payout attempt.
+    var disbursement = modelBuilder.Entity<DisbursementData>();
+    disbursement.HasIndex(x => x.Status); // worker scan: pending/reconcilable disbursements
+    disbursement.HasOne(x => x.Charity)
+                .WithMany()
+                .HasForeignKey(x => x.CharityId)
+                .OnDelete(DeleteBehavior.Cascade);
 
     var charityBalance = modelBuilder.Entity<CharityBalanceData>();
     // One accrual row per (charity, currency): a charity can legitimately receive

--- a/App/StartUp/Options/DisbursementOption.cs
+++ b/App/StartUp/Options/DisbursementOption.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.StartUp.Options;
+
+// Charity payout (disbursement) settings. The donor fields are the legal donor of record
+// (LazyTax) recorded on every Pledge donation; they match the public legal pages.
+public class DisbursementOption
+{
+  public const string Key = "Disbursement";
+
+  // Master switch for the background payout worker. Off by default so the job only runs where
+  // it has been deliberately enabled (e.g. pichu, pointed at Pledge staging).
+  public bool Enabled { get; set; } = false;
+
+  // Skip donating a (charity, currency) group whose accrued total is below this, to avoid
+  // per-donation overhead on trivial amounts. 0 = no threshold.
+  [Range(0, long.MaxValue)] public long MinPayoutCents { get; set; } = 0;
+
+  // Cap on how many (charity, currency) groups are paid out per run.
+  [Range(1, int.MaxValue)] public int MaxGroupsPerRun { get; set; } = 100;
+
+  [Required] public string DonorFirstName { get; set; } = "LazyTax";
+  [Required] public string DonorLastName { get; set; } = "Donations";
+  [Required, EmailAddress] public string DonorEmail { get; set; } = "donations@lazytax.club";
+}

--- a/App/StartUp/Options/OptionsExtensions.cs
+++ b/App/StartUp/Options/OptionsExtensions.cs
@@ -132,6 +132,9 @@ public static class OptionsExtensions
     // Register Payment Options
     services.RegisterOption<PaymentOption>(PaymentOption.Key);
 
+    // Register Disbursement (charity payout) Options
+    services.RegisterOption<DisbursementOption>(DisbursementOption.Key);
+
     return services;
   }
 }

--- a/App/StartUp/Server.cs
+++ b/App/StartUp/Server.cs
@@ -154,6 +154,7 @@ public class Server(
     // Background jobs
     services.AddHostedService<HabitDailyFailureHostedService>();
     services.AddHostedService<PenaltyProcessorHostedService>();
+    services.AddHostedService<App.Modules.Disbursement.DisbursementHostedService>();
 
     // Data seeding for development (lapras only)
     services.AddHostedService<DataSeederHostedService>();

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -114,7 +114,8 @@ These financial storage patterns are used throughout:
 ### Money (Cents + Currency)
 
 - **Habit stakes**: User monetary commitments for habit accountability
-- **Charity donations**: Penalty amounts transferred when habits fail
+- **Charity donations**: Failed-habit penalties are charged to the user's card and later paid out
+  to charities via Pledge (see [Charity payout](#charity-payout-disbursement) below)
 - **Any monetary values**: Precise financial calculations without rounding errors
 
 ### Percentages (Basis Points)
@@ -133,3 +134,64 @@ These financial storage patterns are used throughout:
 6. **Use mappers** to handle conversions between storage and business representations
 
 This ensures all financial calculations are precise and audit-compliant.
+
+## Charity payout (disbursement)
+
+How a failed habit's money actually reaches the charity, end to end:
+
+1. **Charge** (existing): a failed habit execution enqueues a `Penalty`. `PenaltyProcessorHostedService`
+   charges the user's saved card via Airwallex (MIT). On success the penalty is `Charged` and the
+   `(charity, currency)` balance is credited. **The money lands in our (LazyTax) Airwallex account.**
+2. **Claim + donate** (this feature): `DisbursementHostedService` runs daily. It groups
+   `Charged` penalties with `DisbursementId IS NULL` by `(charity, currency)`, and for each group
+   creates a `Disbursement` row (status `Pending`) and stamps those penalties' `DisbursementId`
+   **in one row-locked transaction** — so a retried/parallel pass can never re-select the same
+   penalties and donate twice. It then records a donation to the charity via the **Pledge
+   Donations API** (`POST /v1/donations`), keyed by the `Disbursement.Id` (stored as Pledge
+   `metadata`). On success the disbursement is `Completed`; on failure it is `Failed` and the
+   penalties are **released** (`DisbursementId → NULL`) for a later retry.
+3. **Reconcile**: if we crash after the donation lands but before recording it, the next pass finds
+   the stale `Pending` disbursement and looks it up at Pledge by `metadata`. Found → mark
+   `Completed` (never re-donate); not found → release for a clean retry.
+
+### ⚠️ How settlement _actually_ works (important)
+
+`POST /v1/donations` **does not move money in real time** — it records a donation on Pledge's
+ledger. Pledge then **batches and bills LazyTax's payment method on file** in the Impact Hub.
+Confirmed terms from the staging Impact Hub (Fees and Schedule, 2026-06-29):
+
+- **Billing schedule:** billed **monthly on the 1st**, _or_ sooner when the pending amount reaches
+  the **$50 threshold** (both the billing date and threshold are editable in the Impact Hub).
+- **Fees:** **Donation API fee = 5% + payment processing (2.9% + 30¢ per _batch_ charge, not per
+  donation).** The charity nets ~92% of the gross. `Disbursement.AmountCents` is the **gross** we
+  ask Pledge to donate; Pledge deducts its fee before the charity is paid. Our ledger/reconciliation
+  tracks the gross recorded, not the net the charity receives.
+- **Fee model (decided):** **LazyTax takes 0% and does NOT absorb the fee.** We donate the full
+  amount collected from the user; the donation platform (Pledge) deducts its API + processing fee,
+  and the charity receives the remainder. So we donate as-collected — there is **no gross-up** and
+  **no LazyTax cut**. ⚠️ This means the public copy must NOT claim "100% goes to charity"; the
+  website Terms/marketing (separate repo) must be reworded to: _the money goes to the chosen charity
+  and the charity platform's processing fee — LazyTax keeps none of it._
+
+So:
+
+- **Two separate money flows.** (a) We collect penalties into our **Airwallex** account. (b) Pledge
+  **separately bills LazyTax's payment method on file in the Pledge Impact Hub** (a card/bank set up
+  there) for the batched donation total, then pays the charities. Our code drives flow (a) and the
+  _recording_ of (b) — it does **not** transfer funds to Pledge.
+- **Operational dependency (not code):** the Pledge Impact Hub payment method must exist and stay
+  **funded** (e.g. topped up from Airwallex), or the monthly batch bill fails. This must be set up
+  in **both** the Pledge sandbox (for testing) and production (before go-live).
+- **`Disbursement.Completed` means "donation recorded at Pledge", not "charity has been paid."**
+  True settlement is Pledge's monthly batch. The reconciliation invariant
+  (`sum(charged) == sum(disbursed) + outstanding`) tracks _recorded_ payouts, not settled cash.
+- **Currency:** the donation body has **no currency field** (Pledge bills the account's currency).
+  Multi-currency penalty groups (e.g. SGD + USD) are recorded per-currency on our side but may
+  settle in a single currency at Pledge — confirm against the account before relying on it.
+
+### Safety: never donate against production Pledge in dev
+
+Donations on **`api.pledge.to`** move real money. All dev/testing uses the **staging** host
+**`api-staging.pledge.to`** (a fully isolated sandbox). `pichu` is wired to staging and is the only
+landscape with the disbursement worker enabled (`Disbursement.Enabled: true`). The base host is set
+per-landscape under `HttpClient.PLEDGE.BaseAddress`.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -169,9 +169,9 @@ Confirmed terms from the staging Impact Hub (Fees and Schedule, 2026-06-29):
 - **Fee model (decided):** **LazyTax takes 0% and does NOT absorb the fee.** We donate the full
   amount collected from the user; the donation platform (Pledge) deducts its API + processing fee,
   and the charity receives the remainder. So we donate as-collected — there is **no gross-up** and
-  **no LazyTax cut**. ⚠️ This means the public copy must NOT claim "100% goes to charity"; the
-  website Terms/marketing (separate repo) must be reworded to: _the money goes to the chosen charity
-  and the charity platform's processing fee — LazyTax keeps none of it._
+  **no LazyTax cut**. This is already reflected in the Terms of Service ("100% Donation Policy" /
+  "Fee Transparency": LazyTax donates 100% of penalties _after_ third-party Airwallex + Pledge fees,
+  which it does not control or profit from; LazyTax acts as donor, not the user's agent).
 
 So:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -182,6 +182,19 @@ So:
 - **Operational dependency (not code):** the Pledge Impact Hub payment method must exist and stay
   **funded** (e.g. topped up from Airwallex), or the monthly batch bill fails. This must be set up
   in **both** the Pledge sandbox (for testing) and production (before go-live).
+- **Fee optimization (the cadence that matters is Pledge's, not ours):** our donation-worker
+  schedule (how often `POST /v1/donations` runs) has **zero** fee impact — creating donations only
+  adds to Pledge's running tally; it does not trigger a charge. Fees are set by **Pledge's batch
+  billing** + the **payment method**:
+  - **5% API fee** and the **percentage processing fee** are proportional to the money, so they are
+    cadence-independent.
+  - The **flat/cap part** is charged **once per batch charge to our card** (Pledge batches monthly
+    on the 1st, or sooner at the **$50 threshold** — both editable in the Impact Hub): **card =
+    2.9% + $0.30**, **ACH = 0.8% capped at $5**.
+  - So to minimize fees: prefer **ACH** (capped at $5/batch) and a **larger batch threshold** (fewer
+    batches → the flat/cap applies fewer times). Trade-off: a higher threshold means money sits at
+    Pledge longer before the charity is paid. E.g. a $1,000 batch costs ≈ $29.30 on card vs **$5 on
+    ACH** (plus the 5% API fee either way).
 - **`Disbursement.Completed` means "donation recorded at Pledge", not "charity has been paid."**
   True settlement is Pledge's monthly batch. The reconciliation invariant
   (`sum(charged) == sum(disbursed) + outstanding`) tracks _recorded_ payouts, not settled cash.

--- a/Domain/Disbursement/DonationRejectedException.cs
+++ b/Domain/Disbursement/DonationRejectedException.cs
@@ -1,0 +1,12 @@
+namespace Domain.Disbursement;
+
+// Signals that the donation provider DEFINITIVELY refused the request (a 4xx client error), so no
+// donation was created. This is the only failure where it is safe to release the penalties for a
+// fresh retry. Any other failure (5xx, timeout, network, unparseable body) is AMBIGUOUS — the
+// donation may have landed — and must leave the disbursement Pending for reconciliation instead,
+// otherwise releasing the penalties risks a double payout (Pledge has no idempotency key).
+public class DonationRejectedException : Exception
+{
+  public DonationRejectedException(string? message) : base(message) { }
+  public DonationRejectedException(string? message, Exception? innerException) : base(message, innerException) { }
+}

--- a/Domain/Disbursement/IDonationGateway.cs
+++ b/Domain/Disbursement/IDonationGateway.cs
@@ -1,0 +1,34 @@
+using CSharp_Result;
+using NodaMoney;
+
+namespace Domain.Disbursement;
+
+// Domain port over the donation vendor (Pledge). Keeps the service vendor-agnostic and
+// fakeable; the App layer implements it against the Pledge HTTP client.
+public interface IDonationGateway
+{
+  // Create a donation to a nonprofit. `reference` (our Disbursement.Id) is persisted on the
+  // vendor record (Pledge `metadata`) so a crashed-before-mark attempt can be looked up and
+  // reconciled instead of re-donated.
+  Task<Result<DonationResult>> CreateDonation(DonationRequest req);
+
+  // Look up a previously-created donation by our `reference`. Returns null when none exists
+  // (the create never landed) so the caller can safely release the penalties for a fresh retry.
+  Task<Result<DonationResult?>> FindDonationByReference(string reference);
+}
+
+public record DonationRequest
+{
+  public required string OrganizationId { get; init; }
+  public required Money Amount { get; init; }
+  public required string Reference { get; init; } // our Disbursement.Id; stored as Pledge metadata
+  public required string DonorFirstName { get; init; }
+  public required string DonorLastName { get; init; }
+  public required string DonorEmail { get; init; }
+}
+
+public record DonationResult
+{
+  public required string DonationId { get; init; } // Pledge donation id
+  public required string Status { get; init; }     // Pledge status, e.g. "processed"
+}

--- a/Domain/Disbursement/IService.cs
+++ b/Domain/Disbursement/IService.cs
@@ -1,0 +1,11 @@
+using CSharp_Result;
+
+namespace Domain.Disbursement;
+
+public interface IDisbursementService
+{
+  // Run one payout pass: reconcile any crashed-mid-donation disbursements, then claim and
+  // donate the pending payouts. `donor` is the legal donor of record (LazyTax) recorded on
+  // every Pledge donation. Returns the count of disbursements that reached Completed.
+  Task<Result<int>> ProcessPending(DonorIdentity donor, long minPayoutCents, int maxGroups);
+}

--- a/Domain/Disbursement/Model.cs
+++ b/Domain/Disbursement/Model.cs
@@ -1,0 +1,49 @@
+using NodaMoney;
+
+namespace Domain.Disbursement;
+
+public enum DisbursementStatus
+{
+  Pending,   // claimed (penalties stamped), donation not yet confirmed at Pledge
+  Completed, // Pledge donation created + reconciled; this is the only "paid out" state
+  Failed     // donation attempt failed; penalties were released back to pending-payout
+}
+
+// Business data for one payout to a single (charity, currency).
+public record DisbursementRecord
+{
+  public required Guid CharityId { get; init; }
+  public required Money Amount { get; init; } // currency carried by Money; cents at the data boundary
+  public required string PledgeOrganizationId { get; init; }
+  public required DisbursementStatus Status { get; init; }
+  public string? ProviderDonationId { get; init; } // Pledge donation id, set on Completed
+  public required int Attempts { get; init; }
+  public string? LastError { get; init; }
+}
+
+public record DisbursementPrincipal
+{
+  public required Guid Id { get; init; }
+  public required DisbursementRecord Record { get; init; }
+  public required DateTime CreatedAt { get; init; }
+  public required DateTime UpdatedAt { get; init; }
+}
+
+// Legal donor of record recorded on every donation (LazyTax). Sourced from config.
+public record DonorIdentity
+{
+  public required string FirstName { get; init; }
+  public required string LastName { get; init; }
+  public required string Email { get; init; }
+}
+
+// A claimed payout group: the Disbursement row plus the charity's Pledge org id and the
+// amount to donate. Returned by ClaimPendingPayouts so the worker can issue the donation
+// without re-resolving anything. The penalties are already stamped with DisbursementId.
+public record ClaimedPayout
+{
+  public required Guid DisbursementId { get; init; }
+  public required Guid CharityId { get; init; }
+  public required string PledgeOrganizationId { get; init; }
+  public required Money Amount { get; init; }
+}

--- a/Domain/Disbursement/Model.cs
+++ b/Domain/Disbursement/Model.cs
@@ -29,6 +29,13 @@ public record DisbursementPrincipal
   public required DateTime UpdatedAt { get; init; }
 }
 
+// Full aggregate (no-suffix tier). A disbursement has no extra related entities to compose yet,
+// so it wraps the principal — mirrors Cause/Penalty and lets the data mapper expose ToDomain().
+public record Disbursement
+{
+  public required DisbursementPrincipal Principal { get; init; }
+}
+
 // Legal donor of record recorded on every donation (LazyTax). Sourced from config.
 public record DonorIdentity
 {

--- a/Domain/Disbursement/Repository.cs
+++ b/Domain/Disbursement/Repository.cs
@@ -1,0 +1,27 @@
+using CSharp_Result;
+
+namespace Domain.Disbursement;
+
+public interface IDisbursementRepository
+{
+  // Atomically CLAIM the pending payout: in ONE row-locked transaction, group the charged-but-
+  // unpaid penalties by (charity, currency), and for each group whose total >= minPayoutCents
+  // and whose charity has a Pledge org id, create a Pending Disbursement and stamp those
+  // penalties' DisbursementId. Stamping at claim time is what stops a concurrent or retried pass
+  // from re-selecting the same penalties and double-donating (mirrors the Pending->Processing
+  // claim in the penalty drain). Charities with no Pledge org id are left unclaimed.
+  Task<Result<List<ClaimedPayout>>> ClaimPendingPayouts(long minPayoutCents, int maxGroups);
+
+  // Idempotent terminal success: set Status=Completed + ProviderDonationId. Row-locked; a
+  // repeat (e.g. a reconcile racing the original) is a no-op.
+  Task<Result<Unit>> MarkDisbursed(Guid disbursementId, string providerDonationId);
+
+  // Terminal failure: set Status=Failed, record LastError, bump Attempts, and RELEASE the
+  // claimed penalties (DisbursementId -> NULL) so a later pass re-claims them into a fresh
+  // disbursement. Row-locked + idempotent.
+  Task<Result<Unit>> MarkFailed(Guid disbursementId, string error);
+
+  // Pending disbursements older than `olderThan` — a process that created the donation but
+  // crashed before MarkDisbursed leaves one of these. Reconciled against the vendor.
+  Task<Result<List<DisbursementPrincipal>>> GetReconcilable(TimeSpan olderThan, int batchSize);
+}

--- a/Domain/Disbursement/Service.cs
+++ b/Domain/Disbursement/Service.cs
@@ -1,0 +1,130 @@
+using CSharp_Result;
+using Domain.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace Domain.Disbursement;
+
+public class DisbursementService(
+  IDisbursementRepository repo,
+  IDonationGateway gateway,
+  ILogger<DisbursementService> logger
+) : IDisbursementService
+{
+  // A Pending disbursement still in flight after this long is assumed to belong to a
+  // crashed/hung pass and is eligible for reconciliation against the vendor.
+  private static readonly TimeSpan ReconcileLease = TimeSpan.FromMinutes(10);
+
+  public async Task<Result<int>> ProcessPending(DonorIdentity donor, long minPayoutCents, int maxGroups)
+  {
+    // 1) Reconcile first: settle (or release) any disbursement a previous pass created at the
+    //    vendor but crashed before recording. These rows already have their penalties stamped,
+    //    so the claim below will not re-pick them; reconciling here makes them terminal.
+    var reconciled = await this.ReconcileInflight(maxGroups);
+    if (reconciled.IsFailure())
+      logger.LogError(reconciled.FailureOrDefault(), "Disbursement reconcile pass failed; continuing to claim");
+
+    // 2) Claim and donate the pending payouts.
+    return await repo.ClaimPendingPayouts(minPayoutCents, maxGroups)
+      .ThenAwait(async claimed =>
+      {
+        var results = new List<Result<int>>();
+        foreach (var c in claimed)
+        {
+          try
+          {
+            results.Add(await this.DonateOne(c, donor));
+          }
+          catch (OperationCanceledException)
+          {
+            // Host shutdown must abort the pass, not be swallowed into a Failed.
+            throw;
+          }
+          catch (Exception ex)
+          {
+            // Per-(charity,currency) isolation: one group's unexpected throw must not abort the
+            // batch and strand the rest. Record it against this disbursement (which releases its
+            // penalties for retry) and keep going.
+            logger.LogError(ex, "DonateOne threw for disbursement {Id}; isolating and continuing", c.DisbursementId);
+            try
+            {
+              await repo.MarkFailed(c.DisbursementId, $"unhandled: {ex.Message}");
+            }
+            catch (Exception inner)
+            {
+              logger.LogError(inner, "Failed to record isolation for disbursement {Id}", c.DisbursementId);
+            }
+            results.Add(0);
+          }
+        }
+
+        return results.ToResultOfSeq().Then(xs => xs.Sum(), Errors.MapAll);
+      });
+  }
+
+  private async Task<Result<int>> DonateOne(ClaimedPayout c, DonorIdentity donor)
+  {
+    var req = new DonationRequest
+    {
+      OrganizationId = c.PledgeOrganizationId,
+      Amount = c.Amount,
+      Reference = c.DisbursementId.ToString(),
+      DonorFirstName = donor.FirstName,
+      DonorLastName = donor.LastName,
+      DonorEmail = donor.Email
+    };
+
+    var donation = await gateway.CreateDonation(req);
+    if (donation.IsSuccess())
+    {
+      var d = donation.Get();
+      return await repo.MarkDisbursed(c.DisbursementId, d.DonationId).Then(_ => 1, Errors.MapAll);
+    }
+
+    // Donation failed: release the penalties so a later pass retries them in a fresh disbursement.
+    var ex = donation.FailureOrDefault();
+    return await repo.MarkFailed(c.DisbursementId, ex?.Message ?? "donation error").Then(_ => 0, Errors.MapAll);
+  }
+
+  // For each in-flight (Pending) disbursement past the lease, ask the vendor whether the donation
+  // actually landed (matched by our reference == Disbursement.Id, stored in metadata). If it did,
+  // mark Completed WITHOUT re-donating; if it never landed, release the penalties for a clean retry.
+  private async Task<Result<int>> ReconcileInflight(int batchSize)
+  {
+    return await repo.GetReconcilable(ReconcileLease, batchSize)
+      .ThenAwait(async stale =>
+      {
+        var results = new List<Result<int>>();
+        foreach (var d in stale)
+        {
+          try
+          {
+            var found = await gateway.FindDonationByReference(d.Id.ToString());
+            if (found.IsFailure())
+            {
+              // Unknown vendor state: leave the row Pending so the next pass retries the lookup
+              // rather than risk releasing (and double-donating) a donation that did land.
+              logger.LogWarning(found.FailureOrDefault(), "Reconcile lookup failed for disbursement {Id}; leaving Pending", d.Id);
+              results.Add(0);
+              continue;
+            }
+
+            var donation = found.SuccessOrDefault();
+            results.Add(donation != null
+              ? await repo.MarkDisbursed(d.Id, donation.DonationId).Then(_ => 1, Errors.MapAll)
+              : await repo.MarkFailed(d.Id, "reconcile: no donation found at provider; released for retry").Then(_ => 0, Errors.MapAll));
+          }
+          catch (OperationCanceledException)
+          {
+            throw;
+          }
+          catch (Exception ex)
+          {
+            logger.LogError(ex, "Reconcile threw for disbursement {Id}; leaving Pending", d.Id);
+            results.Add(0);
+          }
+        }
+
+        return results.ToResultOfSeq().Then(xs => xs.Sum(), Errors.MapAll);
+      });
+  }
+}

--- a/Domain/Disbursement/Service.cs
+++ b/Domain/Disbursement/Service.cs
@@ -42,17 +42,10 @@ public class DisbursementService(
           catch (Exception ex)
           {
             // Per-(charity,currency) isolation: one group's unexpected throw must not abort the
-            // batch and strand the rest. Record it against this disbursement (which releases its
-            // penalties for retry) and keep going.
-            logger.LogError(ex, "DonateOne threw for disbursement {Id}; isolating and continuing", c.DisbursementId);
-            try
-            {
-              await repo.MarkFailed(c.DisbursementId, $"unhandled: {ex.Message}");
-            }
-            catch (Exception inner)
-            {
-              logger.LogError(inner, "Failed to record isolation for disbursement {Id}", c.DisbursementId);
-            }
+            // batch and strand the rest. An unhandled throw is AMBIGUOUS (it can happen after the
+            // donation was accepted), so we must NOT release the penalties here — that would risk a
+            // double payout. Leave the disbursement Pending and let the reconcile pass settle it.
+            logger.LogError(ex, "DonateOne threw for disbursement {Id}; leaving Pending for reconciliation", c.DisbursementId);
             results.Add(0);
           }
         }
@@ -80,9 +73,19 @@ public class DisbursementService(
       return await repo.MarkDisbursed(c.DisbursementId, d.DonationId).Then(_ => 1, Errors.MapAll);
     }
 
-    // Donation failed: release the penalties so a later pass retries them in a fresh disbursement.
     var ex = donation.FailureOrDefault();
-    return await repo.MarkFailed(c.DisbursementId, ex?.Message ?? "donation error").Then(_ => 0, Errors.MapAll);
+
+    // DEFINITIVE rejection (4xx): the provider refused and created nothing, so it is safe to release
+    // the penalties for a fresh retry.
+    if (ex is DonationRejectedException)
+      return await repo.MarkFailed(c.DisbursementId, ex.Message).Then(_ => 0, Errors.MapAll);
+
+    // AMBIGUOUS failure (5xx, timeout, network, unparseable body): the donation MAY have landed.
+    // Releasing now would let the next pass re-claim and donate AGAIN (Pledge has no idempotency
+    // key) -> double payout. Leave the disbursement Pending so the reconcile pass settles it by
+    // looking the donation up by our reference before deciding to release.
+    logger.LogWarning(ex, "Donation for disbursement {Id} failed ambiguously; leaving Pending for reconciliation", c.DisbursementId);
+    return 0;
   }
 
   // For each in-flight (Pending) disbursement past the lease, ask the vendor whether the donation

--- a/Domain/Penalty/Model.cs
+++ b/Domain/Penalty/Model.cs
@@ -21,6 +21,8 @@ public record PenaltyRecord
   public string? PaymentIntentId { get; init; }
   public required int Attempts { get; init; }
   public string? LastError { get; init; }
+  // Payout linkage: null while pending payout, set once a disbursement has claimed it.
+  public Guid? DisbursementId { get; init; }
 }
 
 public record PenaltyPrincipal

--- a/IntTest/DbIntegrationCollection.cs
+++ b/IntTest/DbIntegrationCollection.cs
@@ -1,0 +1,12 @@
+namespace IntTest;
+
+// All DB-backed integration test classes share ONE Postgres (from PENALTY_TEST_DB) and manage
+// its schema with EnsureCreated/EnsureDeleted in their lifecycle. xUnit runs distinct test
+// classes in parallel by default, so two such classes would race on the same database (one
+// dropping it mid-run of the other). Assigning them to a single collection makes xUnit run them
+// serially. New DB-backed int classes should carry [Collection(DbIntegrationCollection.Name)].
+[CollectionDefinition(Name)]
+public class DbIntegrationCollection
+{
+  public const string Name = "DbIntegration";
+}

--- a/IntTest/Disbursement/DisbursementIntegrationTests.cs
+++ b/IntTest/Disbursement/DisbursementIntegrationTests.cs
@@ -1,0 +1,298 @@
+using App.Modules.Charities.Data;
+using App.Modules.Disbursement.Data;
+using App.Modules.HabitExecution.Data;
+using App.Modules.Penalty.Data;
+using App.Modules.Users.Data;
+using App.StartUp.Database;
+using App.StartUp.Options;
+using CSharp_Result;
+using Domain.Disbursement;
+using Domain.Penalty;
+using IntTest.Penalty;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaMoney;
+
+namespace IntTest.Disbursement;
+
+// DB-backed integration tests proving the payout claim/mark/release ledger against a REAL
+// MainDbContext: grouped-and-stamped claim, no-org-id skip, min-payout threshold, idempotent
+// MarkDisbursed, MarkFailed-releases-penalties, and a full claim->donate->mark round trip.
+//
+// Like the penalty suite, these require a real Postgres (raw FOR UPDATE + transactions). The
+// connection comes from PENALTY_TEST_DB; when unset the tests Skip rather than fail.
+[Collection(DbIntegrationCollection.Name)]
+public class DisbursementIntegrationTests : IAsyncLifetime
+{
+  private const string SkipReason = "PENALTY_TEST_DB not set; skipping DB-backed disbursement integration test.";
+  private readonly string? _conn = Environment.GetEnvironmentVariable("PENALTY_TEST_DB");
+  private MainDbContext _db = null!;
+
+  public async Task InitializeAsync()
+  {
+    if (_conn == null) return;
+    _db = NewContext(_conn);
+    await _db.Database.EnsureCreatedAsync();
+  }
+
+  public async Task DisposeAsync()
+  {
+    if (_conn == null) return;
+    await _db.Database.EnsureDeletedAsync();
+    await _db.DisposeAsync();
+  }
+
+  private static MainDbContext NewContext(string conn)
+  {
+    var parts = conn.Split(';', StringSplitOptions.RemoveEmptyEntries)
+      .Select(p => p.Split('=', 2))
+      .Where(kv => kv.Length == 2)
+      .ToDictionary(kv => kv[0].Trim().ToLowerInvariant(), kv => kv[1].Trim());
+
+    var opt = new DatabaseOption
+    {
+      Host = parts.GetValueOrDefault("host", "localhost"),
+      Port = int.TryParse(parts.GetValueOrDefault("port", "5432"), out var p) ? p : 5432,
+      Database = parts.GetValueOrDefault("database", "penalty_test"),
+      User = parts.GetValueOrDefault("username", parts.GetValueOrDefault("user", "postgres")),
+      Password = parts.GetValueOrDefault("password", "postgres"),
+      AutoMigrate = false,
+      Timeout = 30
+    };
+    var monitor = new StaticOptionsMonitor<Dictionary<string, DatabaseOption>>(
+      new Dictionary<string, DatabaseOption> { [MainDbContext.Key] = opt });
+    return new MainDbContext(monitor, NullLoggerFactory.Instance);
+  }
+
+  private static DisbursementRepository Repo(MainDbContext db)
+    => new(db, NullLogger<DisbursementRepository>.Instance);
+
+  private static DisbursementService Service(IDisbursementRepository repo, IDonationGateway gw)
+    => new(repo, gw, NullLogger<DisbursementService>.Instance);
+
+  private static readonly DonorIdentity Donor = new()
+  {
+    FirstName = "LazyTax", LastName = "Donations", Email = "donations@lazytax.club"
+  };
+
+  private async Task<(string userId, Guid charityId)> SeedUserAndCharity(string? pledgeOrgId = "org_pledge_1")
+  {
+    var userId = $"user-{Guid.NewGuid():N}";
+    var charityId = Guid.NewGuid();
+    _db.Users.Add(new UserData { Id = userId, Username = userId, Email = $"{userId}@test.local" });
+    _db.Charities.Add(new CharityData { Id = charityId, Name = $"Charity {charityId:N}" });
+    if (pledgeOrgId != null)
+      _db.ExternalIds.Add(new ExternalIdData { Source = "pledge", ExternalKey = pledgeOrgId, CharityId = charityId });
+    await _db.SaveChangesAsync();
+    return (userId, charityId);
+  }
+
+  private async Task<Guid> SeedExecution(string userId, Guid charityId)
+  {
+    var habitId = Guid.NewGuid();
+    var versionId = Guid.NewGuid();
+    var executionId = Guid.NewGuid();
+    _db.Habits.Add(new App.Modules.Habit.Data.HabitData { Id = habitId, UserId = userId, Version = 1, Enabled = true });
+    _db.HabitVersions.Add(new App.Modules.HabitVersion.Data.HabitVersionData
+    {
+      Id = versionId,
+      HabitId = habitId,
+      CharityId = charityId,
+      Version = 1,
+      Task = $"task-{versionId:N}",
+      DaysOfWeek = ["Monday"],
+      Timezone = "Asia/Singapore"
+    });
+    _db.HabitExecutions.Add(new HabitExecutionData
+    {
+      Id = executionId,
+      HabitVersionId = versionId,
+      Date = DateOnly.FromDateTime(DateTime.UtcNow),
+      Status = HabitExecutionStatusData.Failed
+    });
+    await _db.SaveChangesAsync();
+    return executionId;
+  }
+
+  // Insert a Charged, not-yet-disbursed penalty (the input to the payout pipeline).
+  private async Task<Guid> SeedChargedPenalty(string userId, Guid charityId, long amountCents, string currency = "USD")
+  {
+    var executionId = await SeedExecution(userId, charityId);
+    var p = new PenaltyData
+    {
+      Id = Guid.NewGuid(),
+      HabitExecutionId = executionId,
+      UserId = userId,
+      CharityId = charityId,
+      AmountCents = (int)amountCents,
+      Currency = currency,
+      Status = (int)PenaltyStatus.Charged,
+      PaymentIntentId = "pi_test",
+      Attempts = 1,
+      DisbursementId = null
+    };
+    _db.Penalties.Add(p);
+    await _db.SaveChangesAsync();
+    return p.Id;
+  }
+
+  [SkippableFact]
+  public async Task Claim_GroupsByCharityCurrency_CreatesDisbursement_StampsPenalties()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    var id1 = await SeedChargedPenalty(userId, charityId, 300);
+    var id2 = await SeedChargedPenalty(userId, charityId, 200);
+
+    var claimed = (await Repo(_db).ClaimPendingPayouts(minPayoutCents: 0, maxGroups: 100)).Get();
+
+    claimed.Should().ContainSingle();
+    claimed[0].CharityId.Should().Be(charityId);
+    claimed[0].PledgeOrganizationId.Should().Be("org_pledge_1");
+    claimed[0].Amount.Amount.Should().Be(5.00m); // 300 + 200 cents summed
+
+    await using var verify = NewContext(_conn!);
+    var disb = await verify.Disbursements.AsNoTracking().SingleAsync(d => d.CharityId == charityId);
+    disb.AmountCents.Should().Be(500);
+    disb.Status.Should().Be((int)DisbursementStatus.Pending);
+    disb.PledgeOrganizationId.Should().Be("org_pledge_1");
+
+    // Both penalties stamped with the disbursement id (claimed, excluded from re-selection).
+    var penalties = await verify.Penalties.AsNoTracking().Where(x => x.UserId == userId).ToListAsync();
+    penalties.Should().OnlyContain(x => x.DisbursementId == disb.Id);
+    penalties.Select(x => x.Id).Should().BeEquivalentTo(new[] { id1, id2 });
+  }
+
+  [SkippableFact]
+  public async Task Claim_DifferentCurrenciesSameCharity_ProduceSeparateDisbursements()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 500, "USD");
+    await SeedChargedPenalty(userId, charityId, 300, "SGD");
+
+    var claimed = (await Repo(_db).ClaimPendingPayouts(0, 100)).Get();
+
+    claimed.Should().HaveCount(2); // one per (charity, currency)
+    await using var verify = NewContext(_conn!);
+    var disbs = await verify.Disbursements.AsNoTracking().Where(d => d.CharityId == charityId).ToListAsync();
+    disbs.Should().HaveCount(2);
+    disbs.Single(d => d.Currency == "USD").AmountCents.Should().Be(500);
+    disbs.Single(d => d.Currency == "SGD").AmountCents.Should().Be(300);
+  }
+
+  [SkippableFact]
+  public async Task Claim_NoPledgeOrgId_LeavesPenaltiesUnclaimed()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity(pledgeOrgId: null); // charity has no pledge link
+    await SeedChargedPenalty(userId, charityId, 500);
+
+    var claimed = (await Repo(_db).ClaimPendingPayouts(0, 100)).Get();
+
+    claimed.Should().BeEmpty();
+    await using var verify = NewContext(_conn!);
+    (await verify.Disbursements.AsNoTracking().AnyAsync(d => d.CharityId == charityId)).Should().BeFalse();
+    // Penalty stays pending payout (DisbursementId still null) for once the charity is synced.
+    (await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId)).DisbursementId.Should().BeNull();
+  }
+
+  [SkippableFact]
+  public async Task Claim_BelowMinPayoutThreshold_IsSkipped()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 50); // $0.50, below a $1.00 threshold
+
+    var claimed = (await Repo(_db).ClaimPendingPayouts(minPayoutCents: 100, maxGroups: 100)).Get();
+
+    claimed.Should().BeEmpty();
+    await using var verify = NewContext(_conn!);
+    (await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId)).DisbursementId.Should().BeNull();
+  }
+
+  [SkippableFact]
+  public async Task Claim_DoesNotReSelectAlreadyClaimedPenalties()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 500);
+
+    (await Repo(_db).ClaimPendingPayouts(0, 100)).Get().Should().ContainSingle();
+    // Second claim finds nothing pending (the penalties are stamped) -> no double-donate.
+    await using var c2 = NewContext(_conn!);
+    (await Repo(c2).ClaimPendingPayouts(0, 100)).Get().Should().BeEmpty();
+  }
+
+  [SkippableFact]
+  public async Task MarkDisbursed_SetsCompleted_AndIsIdempotent()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 500);
+    var disbId = (await Repo(_db).ClaimPendingPayouts(0, 100)).Get().Single().DisbursementId;
+
+    await using (var c1 = NewContext(_conn!)) (await Repo(c1).MarkDisbursed(disbId, "don_1")).Get();
+    // Second call (e.g. a reconcile racing the original) must be a no-op, not overwrite.
+    await using (var c2 = NewContext(_conn!)) (await Repo(c2).MarkDisbursed(disbId, "don_2")).Get();
+
+    await using var verify = NewContext(_conn!);
+    var d = await verify.Disbursements.AsNoTracking().SingleAsync(x => x.Id == disbId);
+    d.Status.Should().Be((int)DisbursementStatus.Completed);
+    d.ProviderDonationId.Should().Be("don_1"); // first winner kept
+  }
+
+  [SkippableFact]
+  public async Task MarkFailed_ReleasesPenalties_ForRetry()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 500);
+    var disbId = (await Repo(_db).ClaimPendingPayouts(0, 100)).Get().Single().DisbursementId;
+
+    await using (var c1 = NewContext(_conn!)) (await Repo(c1).MarkFailed(disbId, "pledge 422")).Get();
+
+    await using var verify = NewContext(_conn!);
+    var d = await verify.Disbursements.AsNoTracking().SingleAsync(x => x.Id == disbId);
+    d.Status.Should().Be((int)DisbursementStatus.Failed);
+    d.LastError.Should().Be("pledge 422");
+    d.Attempts.Should().Be(1);
+    // Penalty released back to pending payout (DisbursementId null) so a later pass re-claims it.
+    (await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId)).DisbursementId.Should().BeNull();
+  }
+
+  [SkippableFact]
+  public async Task FullRoundTrip_ClaimDonateMark_CompletesAndStaysClaimed()
+  {
+    Skip.If(_conn == null, SkipReason);
+
+    var (userId, charityId) = await SeedUserAndCharity();
+    await SeedChargedPenalty(userId, charityId, 500);
+
+    var gw = StubDonationGateway.Succeeds("don_rt");
+    var count = (int)await Service(Repo(_db), gw).ProcessPending(Donor, 0, 100);
+    count.Should().Be(1);
+
+    gw.CreateCalls.Should().ContainSingle();
+    gw.CreateCalls[0].OrganizationId.Should().Be("org_pledge_1");
+    gw.CreateCalls[0].Amount.Amount.Should().Be(5.00m);
+
+    await using var verify = NewContext(_conn!);
+    var d = await verify.Disbursements.AsNoTracking().SingleAsync(x => x.CharityId == charityId);
+    d.Status.Should().Be((int)DisbursementStatus.Completed);
+    d.ProviderDonationId.Should().Be("don_rt");
+    // The penalty remains stamped to the completed disbursement (the audit trail).
+    (await verify.Penalties.AsNoTracking().SingleAsync(x => x.UserId == userId)).DisbursementId.Should().Be(d.Id);
+
+    // A second pass has nothing left to do.
+    await using var c2 = NewContext(_conn!);
+    ((int)await Service(Repo(c2), gw).ProcessPending(Donor, 0, 100)).Should().Be(0);
+  }
+}

--- a/IntTest/Disbursement/StubDonationGateway.cs
+++ b/IntTest/Disbursement/StubDonationGateway.cs
@@ -1,0 +1,25 @@
+using CSharp_Result;
+using Domain.Disbursement;
+
+namespace IntTest.Disbursement;
+
+// Minimal IDonationGateway stub for the DB-backed round-trip test: records CreateDonation calls
+// and returns a canned result, so the test exercises the real repository ledger without a vendor.
+public sealed class StubDonationGateway(
+  Func<DonationRequest, Result<DonationResult>> create,
+  Func<string, Result<DonationResult?>>? find = null) : IDonationGateway
+{
+  public List<DonationRequest> CreateCalls { get; } = [];
+
+  public static StubDonationGateway Succeeds(string donationId)
+    => new(_ => new DonationResult { DonationId = donationId, Status = "processed" });
+
+  public Task<Result<DonationResult>> CreateDonation(DonationRequest req)
+  {
+    CreateCalls.Add(req);
+    return Task.FromResult(create(req));
+  }
+
+  public Task<Result<DonationResult?>> FindDonationByReference(string reference)
+    => Task.FromResult(find?.Invoke(reference) ?? (DonationResult?)null);
+}

--- a/IntTest/Penalty/PenaltyIntegrationTests.cs
+++ b/IntTest/Penalty/PenaltyIntegrationTests.cs
@@ -28,6 +28,7 @@ namespace IntTest.Penalty;
 // When it is not set the tests Skip rather than fail, so the suite is green in
 // environments without a database while still exercising the full L3->L6 path
 // wherever Postgres is available (CI / the later build phase).
+[Collection(DbIntegrationCollection.Name)]
 public class PenaltyIntegrationTests : IAsyncLifetime
 {
   private const string SkipReason = "PENALTY_TEST_DB not set; skipping DB-backed penalty integration test.";

--- a/UnitTest/Disbursement/DisbursementServiceTests.cs
+++ b/UnitTest/Disbursement/DisbursementServiceTests.cs
@@ -68,11 +68,12 @@ public class DisbursementServiceTests
   }
 
   [Fact]
-  public async Task DonationFails_MarksFailed_ReleasesForRetry_NotCounted()
+  public async Task DefinitiveRejection_MarksFailed_ReleasesForRetry_NotCounted()
   {
+    // A 4xx provider rejection means nothing was created -> safe to release the penalties.
     var p = Payout();
     var repo = new FakeDisbursementRepository(claim: [p]);
-    var gw = FakeDonationGateway.Fails(new Exception("pledge 422"));
+    var gw = FakeDonationGateway.Rejects("rejected with status 422");
     var svc = Build(repo, gw);
 
     var res = await svc.ProcessPending(Donor, 0, 100);
@@ -84,9 +85,29 @@ public class DisbursementServiceTests
   }
 
   [Fact]
-  public async Task CreateThrows_IsolatedToThatGroup_BatchKeepsDonating()
+  public async Task AmbiguousFailure_StaysPending_DoesNotReleaseOrReDonate()
   {
-    // An unhandled throw on one group's donation must NOT abort the batch and strand the rest.
+    // The money-twice guard: a 5xx/timeout/unknown failure may mean the donation landed. The
+    // disbursement must stay Pending (no MarkFailed -> penalties NOT released) so reconciliation
+    // settles it; otherwise a re-claim would donate a second time.
+    var p = Payout();
+    var repo = new FakeDisbursementRepository(claim: [p]);
+    var gw = FakeDonationGateway.Fails(new Exception("503 gateway timeout"));
+    var svc = Build(repo, gw);
+
+    var res = await svc.ProcessPending(Donor, 0, 100);
+
+    ((int)res).Should().Be(0);
+    repo.MarkFailedCalls.Should().BeEmpty();    // penalties NOT released
+    repo.MarkDisbursedCalls.Should().BeEmpty(); // not completed either -> left Pending
+  }
+
+  [Fact]
+  public async Task CreateThrows_IsolatedToThatGroup_LeavesItPending_BatchKeepsDonating()
+  {
+    // An unhandled throw on one group must NOT abort the batch — and (money-twice guard) must NOT
+    // release that group's penalties (the throw can follow an accepted donation). It stays Pending;
+    // the next group still donates.
     var p1 = Payout();
     var p2 = Payout();
     var repo = new FakeDisbursementRepository(claim: [p1, p2]);
@@ -96,7 +117,7 @@ public class DisbursementServiceTests
     var res = await svc.ProcessPending(Donor, 0, 100);
 
     res.IsSuccess().Should().BeTrue();                                   // pass did not crash
-    repo.MarkFailedCalls.Should().ContainSingle().Which.Id.Should().Be(p1.DisbursementId);   // p1 throw -> released
+    repo.MarkFailedCalls.Should().BeEmpty();                             // p1 throw -> left Pending, NOT released
     repo.MarkDisbursedCalls.Should().ContainSingle().Which.Should().Be((p2.DisbursementId, "don_ok")); // p2 still donated
     ((int)res).Should().Be(1);
   }

--- a/UnitTest/Disbursement/DisbursementServiceTests.cs
+++ b/UnitTest/Disbursement/DisbursementServiceTests.cs
@@ -1,0 +1,154 @@
+using Domain.Disbursement;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaMoney;
+
+namespace UnitTest.Disbursement;
+
+// Service-level tests for the payout matrix: donate-success, donate-failure-release,
+// per-group isolation, and the reconcile (found -> mark, not-found -> release) paths.
+public class DisbursementServiceTests
+{
+  private static readonly DonorIdentity Donor = new()
+  {
+    FirstName = "LazyTax",
+    LastName = "Donations",
+    Email = "donations@lazytax.club"
+  };
+
+  private static ClaimedPayout Payout(decimal amount = 5.00m, string currency = "USD", string org = "org_1")
+    => new()
+    {
+      DisbursementId = Guid.NewGuid(),
+      CharityId = Guid.NewGuid(),
+      PledgeOrganizationId = org,
+      Amount = new Money(amount, Currency.FromCode(currency))
+    };
+
+  private static DisbursementPrincipal Inflight(decimal amount = 5.00m, string currency = "USD")
+    => new()
+    {
+      Id = Guid.NewGuid(),
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow,
+      Record = new DisbursementRecord
+      {
+        CharityId = Guid.NewGuid(),
+        Amount = new Money(amount, Currency.FromCode(currency)),
+        PledgeOrganizationId = "org_1",
+        Status = DisbursementStatus.Pending,
+        ProviderDonationId = null,
+        Attempts = 0,
+        LastError = null
+      }
+    };
+
+  private static DisbursementService Build(FakeDisbursementRepository repo, FakeDonationGateway gw)
+    => new(repo, gw, NullLogger<DisbursementService>.Instance);
+
+  [Fact]
+  public async Task DonationSucceeds_MarksDisbursedOnce_AndCounts()
+  {
+    var p = Payout();
+    var repo = new FakeDisbursementRepository(claim: [p]);
+    var gw = FakeDonationGateway.Succeeds("don_123");
+    var svc = Build(repo, gw);
+
+    var res = await svc.ProcessPending(Donor, minPayoutCents: 0, maxGroups: 100);
+
+    res.IsSuccess().Should().BeTrue();
+    ((int)res).Should().Be(1);
+    repo.MarkDisbursedCalls.Should().ContainSingle();
+    repo.MarkDisbursedCalls[0].Should().Be((p.DisbursementId, "don_123"));
+    repo.MarkFailedCalls.Should().BeEmpty();
+    // Donation carried the disbursement id as the reconcile reference + the LazyTax donor.
+    gw.CreateCalls.Should().ContainSingle();
+    gw.CreateCalls[0].Reference.Should().Be(p.DisbursementId.ToString());
+    gw.CreateCalls[0].DonorEmail.Should().Be("donations@lazytax.club");
+    gw.CreateCalls[0].Amount.Amount.Should().Be(5.00m);
+  }
+
+  [Fact]
+  public async Task DonationFails_MarksFailed_ReleasesForRetry_NotCounted()
+  {
+    var p = Payout();
+    var repo = new FakeDisbursementRepository(claim: [p]);
+    var gw = FakeDonationGateway.Fails(new Exception("pledge 422"));
+    var svc = Build(repo, gw);
+
+    var res = await svc.ProcessPending(Donor, 0, 100);
+
+    ((int)res).Should().Be(0);
+    repo.MarkFailedCalls.Should().ContainSingle();
+    repo.MarkFailedCalls[0].Id.Should().Be(p.DisbursementId);
+    repo.MarkDisbursedCalls.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task CreateThrows_IsolatedToThatGroup_BatchKeepsDonating()
+  {
+    // An unhandled throw on one group's donation must NOT abort the batch and strand the rest.
+    var p1 = Payout();
+    var p2 = Payout();
+    var repo = new FakeDisbursementRepository(claim: [p1, p2]);
+    var gw = FakeDonationGateway.ThrowsOnFirstThenSucceeds(new Exception("malformed"), "don_ok");
+    var svc = Build(repo, gw);
+
+    var res = await svc.ProcessPending(Donor, 0, 100);
+
+    res.IsSuccess().Should().BeTrue();                                   // pass did not crash
+    repo.MarkFailedCalls.Should().ContainSingle().Which.Id.Should().Be(p1.DisbursementId);   // p1 throw -> released
+    repo.MarkDisbursedCalls.Should().ContainSingle().Which.Should().Be((p2.DisbursementId, "don_ok")); // p2 still donated
+    ((int)res).Should().Be(1);
+  }
+
+  [Fact]
+  public async Task EachGroupDonatedExactlyOnce()
+  {
+    var p1 = Payout();
+    var p2 = Payout();
+    var repo = new FakeDisbursementRepository(claim: [p1, p2]);
+    var gw = FakeDonationGateway.Succeeds("don_x");
+    var svc = Build(repo, gw);
+
+    var res = await svc.ProcessPending(Donor, 0, 100);
+
+    ((int)res).Should().Be(2);
+    repo.MarkDisbursedCalls.Select(c => c.Id).Should().BeEquivalentTo(new[] { p1.DisbursementId, p2.DisbursementId });
+    repo.MarkDisbursedCalls.Select(c => c.Id).Distinct().Should().HaveCount(2);
+  }
+
+  [Fact]
+  public async Task Reconcile_FindsExistingDonation_MarksDisbursed_DoesNotReDonate()
+  {
+    // Crash-after-donation-before-mark: the donation already landed at the vendor. Reconcile must
+    // mark it Completed via the looked-up id, NOT issue a second donation.
+    var stale = Inflight();
+    var repo = new FakeDisbursementRepository(reconcilable: [stale]);
+    var gw = FakeDonationGateway.FindsExisting("don_found");
+    var svc = Build(repo, gw);
+
+    await svc.ProcessPending(Donor, 0, 100);
+
+    gw.FindCalls.Should().ContainSingle().Which.Should().Be(stale.Id.ToString());
+    repo.MarkDisbursedCalls.Should().ContainSingle();
+    repo.MarkDisbursedCalls[0].Should().Be((stale.Id, "don_found"));
+    gw.CreateCalls.Should().BeEmpty();          // never re-donated
+    repo.MarkFailedCalls.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Reconcile_FindsNothing_ReleasesForRetry()
+  {
+    // The donation never landed at the vendor -> release the penalties (MarkFailed) for a fresh retry.
+    var stale = Inflight();
+    var repo = new FakeDisbursementRepository(reconcilable: [stale]);
+    var gw = FakeDonationGateway.FindsNothing();
+    var svc = Build(repo, gw);
+
+    await svc.ProcessPending(Donor, 0, 100);
+
+    gw.FindCalls.Should().ContainSingle();
+    repo.MarkFailedCalls.Should().ContainSingle().Which.Id.Should().Be(stale.Id);
+    repo.MarkDisbursedCalls.Should().BeEmpty();
+  }
+}

--- a/UnitTest/Disbursement/Fakes.cs
+++ b/UnitTest/Disbursement/Fakes.cs
@@ -64,8 +64,13 @@ public sealed class FakeDonationGateway : IDonationGateway
     => new(_ => new DonationResult { DonationId = donationId, Status = "processed" },
            _ => (DonationResult?)null);
 
+  // Ambiguous failure (5xx/timeout/etc.): the donation may have landed -> caller must keep Pending.
   public static FakeDonationGateway Fails(Exception ex)
     => new(_ => ex, _ => (DonationResult?)null);
+
+  // Definitive provider rejection (4xx): no donation created -> caller releases for retry.
+  public static FakeDonationGateway Rejects(string reason = "rejected")
+    => new(_ => new DonationRejectedException(reason), _ => (DonationResult?)null);
 
   // First create throws, later creates succeed.
   public static FakeDonationGateway ThrowsOnFirstThenSucceeds(Exception ex, string donationId = "don_ok")

--- a/UnitTest/Disbursement/Fakes.cs
+++ b/UnitTest/Disbursement/Fakes.cs
@@ -1,0 +1,98 @@
+using CSharp_Result;
+using Domain.Disbursement;
+
+namespace UnitTest.Disbursement;
+
+// Hand-rolled fakes implementing the real L3/L4 contracts so the service unit tests can assert
+// the donate/reconcile/isolation matrix without a mocking framework (Moq is not referenced).
+
+public sealed class FakeDisbursementRepository(
+  IEnumerable<ClaimedPayout>? claim = null,
+  IEnumerable<DisbursementPrincipal>? reconcilable = null) : IDisbursementRepository
+{
+  private readonly List<ClaimedPayout> _claim = [.. claim ?? []];
+  private readonly List<DisbursementPrincipal> _reconcilable = [.. reconcilable ?? []];
+
+  public List<(Guid Id, string ProviderDonationId)> MarkDisbursedCalls { get; } = [];
+  public List<(Guid Id, string Error)> MarkFailedCalls { get; } = [];
+  public int ClaimCalls { get; private set; }
+
+  public Task<Result<List<ClaimedPayout>>> ClaimPendingPayouts(long minPayoutCents, int maxGroups)
+  {
+    ClaimCalls++;
+    return Task.FromResult<Result<List<ClaimedPayout>>>(_claim.Take(maxGroups).ToList());
+  }
+
+  public Task<Result<Unit>> MarkDisbursed(Guid disbursementId, string providerDonationId)
+  {
+    MarkDisbursedCalls.Add((disbursementId, providerDonationId));
+    return Task.FromResult<Result<Unit>>(new Unit());
+  }
+
+  public Task<Result<Unit>> MarkFailed(Guid disbursementId, string error)
+  {
+    MarkFailedCalls.Add((disbursementId, error));
+    return Task.FromResult<Result<Unit>>(new Unit());
+  }
+
+  public Task<Result<List<DisbursementPrincipal>>> GetReconcilable(TimeSpan olderThan, int batchSize)
+    => Task.FromResult<Result<List<DisbursementPrincipal>>>(_reconcilable.Take(batchSize).ToList());
+}
+
+public sealed class FakeDonationGateway : IDonationGateway
+{
+  private readonly Func<DonationRequest, Result<DonationResult>> _create;
+  private readonly Func<string, Result<DonationResult?>> _find;
+
+  // If set, the FIRST CreateDonation throws (simulates an unhandled vendor exception); later
+  // calls run normally — to test per-group batch isolation.
+  public Exception? ThrowOnFirstCreate { get; init; }
+  private int _createCalls;
+
+  private FakeDonationGateway(
+    Func<DonationRequest, Result<DonationResult>> create,
+    Func<string, Result<DonationResult?>> find)
+  {
+    _create = create;
+    _find = find;
+  }
+
+  public List<DonationRequest> CreateCalls { get; } = [];
+  public List<string> FindCalls { get; } = [];
+
+  public static FakeDonationGateway Succeeds(string donationId = "don_ok")
+    => new(_ => new DonationResult { DonationId = donationId, Status = "processed" },
+           _ => (DonationResult?)null);
+
+  public static FakeDonationGateway Fails(Exception ex)
+    => new(_ => ex, _ => (DonationResult?)null);
+
+  // First create throws, later creates succeed.
+  public static FakeDonationGateway ThrowsOnFirstThenSucceeds(Exception ex, string donationId = "don_ok")
+    => new(_ => new DonationResult { DonationId = donationId, Status = "processed" },
+           _ => (DonationResult?)null)
+    { ThrowOnFirstCreate = ex };
+
+  // Reconcile: the lookup finds an already-created donation (so the service must NOT re-donate).
+  public static FakeDonationGateway FindsExisting(string donationId)
+    => new(_ => new DonationResult { DonationId = "should_not_be_called", Status = "processed" },
+           _ => new DonationResult { DonationId = donationId, Status = "processed" });
+
+  // Reconcile: the lookup finds nothing (the donation never landed -> release for retry).
+  public static FakeDonationGateway FindsNothing()
+    => new(_ => new DonationResult { DonationId = "don_ok", Status = "processed" },
+           _ => (DonationResult?)null);
+
+  public Task<Result<DonationResult>> CreateDonation(DonationRequest req)
+  {
+    CreateCalls.Add(req);
+    if (ThrowOnFirstCreate != null && _createCalls++ == 0) throw ThrowOnFirstCreate;
+    return Task.FromResult(_create(req));
+  }
+
+  public Task<Result<DonationResult?>> FindDonationByReference(string reference)
+  {
+    FindCalls.Add(reference);
+    return Task.FromResult(_find(reference));
+  }
+}

--- a/infra/api_chart/app/settings.pichu.yaml
+++ b/infra/api_chart/app/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
+# run the disbursement worker here. Donations hit the Pledge sandbox, never production.
+Disbursement:
+  Enabled: true
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -215,3 +215,12 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+Disbursement:
+  Enabled: false
+  MinPayoutCents: 0
+  MaxGroupsPerRun: 100
+  DonorFirstName: LazyTax
+  DonorLastName: Donations
+  DonorEmail: donations@lazytax.club

--- a/infra/migration_chart/app/settings.pichu.yaml
+++ b/infra/migration_chart/app/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
+# run the disbursement worker here. Donations hit the Pledge sandbox, never production.
+Disbursement:
+  Enabled: true
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -215,3 +215,12 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+Disbursement:
+  Enabled: false
+  MinPayoutCents: 0
+  MaxGroupsPerRun: 100
+  DonorFirstName: LazyTax
+  DonorLastName: Donations
+  DonorEmail: donations@lazytax.club


### PR DESCRIPTION
## What

Builds **charity disbursement**: pays out accrued penalties to charities via the **Pledge Donations API**, on a scheduled batch, with **per-penalty tracking** (Option 2). Closes the liability gap where `Charged` penalties were credited to a write-only `CharityBalances` ledger but never actually paid out.

ClickUp: [86ey38q33](https://app.clickup.com/t/86ey38q33) (subtask [86ey392bh](https://app.clickup.com/t/86ey392bh)).

> ⚠️ Donations were validated against the **Pledge STAGING sandbox** (`api-staging.pledge.to`) only — never production. The worker is enabled on **pichu only** (its Pledge base URL points at staging).

## How it works

1. **Charge** (existing): failed habit → `Penalty` charged via Airwallex → `Charged` + charity balance credited. Money lands in our Airwallex account.
2. **Claim + donate** (new): `DisbursementHostedService` (daily) groups `Charged` penalties with `DisbursementId IS NULL` by `(charity, currency)`; in **one row-locked transaction** it creates a `Disbursement` (Pending) and **stamps the penalties' `DisbursementId`** — so a retried/parallel pass can never re-select them and double-donate. Then it records the donation via `POST /v1/donations` (keyed by `Disbursement.Id` in Pledge `metadata`). Success → `Completed`; failure → `Failed` + penalties **released** for retry.
3. **Reconcile**: crash after donation lands but before recording → next pass finds the stale `Pending` disbursement and looks it up at Pledge by `metadata`; found → `Completed` (never re-donate); not found → release for clean retry. (Pledge has no client idempotency key, so reconciliation is a metadata lookup.)

Mirrors the existing penalty patterns: idempotent + row-locked like `MarkCharged`, reconcile-not-recreate like the intent-id fix, per-item batch isolation.

## Changes

- **Schema**: `Disbursements` table + `Penalty.DisbursementId` FK + migration `AddDisbursement`.
- **Domain** (`Domain/Disbursement/`): model, repo port, `IDonationGateway` port, service.
- **App**: `DisbursementRepository` (`ClaimPendingPayouts`/`MarkDisbursed`/`MarkFailed`/`GetReconcilable`), `PledgeDonationGateway`, `DisbursementHostedService`, `DisbursementOption`, `PledgeClient.CreateDonation`/`GetDonations`.
- **Config**: `Disbursement` section (disabled by default; `Enabled: true` on pichu), config-synced to infra charts.
- **Tests**: unit (donate/reconcile/isolation matrix) + real-DB integration (grouped claim, no-org-id skip, min-payout threshold, idempotent `MarkDisbursed`, `MarkFailed` release, full round-trip), gated by `PENALTY_TEST_DB`. DB int classes share one xUnit collection so they don't race the penalty suite.
- **Docs**: `DEVELOPER.md` "Charity payout" section incl. how settlement actually works.

## Testing

- Unit: 6 new (all green).
- Integration: 8 new against a real Postgres (all green); existing penalty int suite still green.

## Follow-ups (tracked on the ticket — not code)

- 💰 **Settlement reality**: `POST /donations` only *records*; Pledge **batches monthly (1st) / at $50** and bills **LazyTax's Impact Hub payment method** (~**5% + 2.9%+30¢ card / 0.8% $5-cap ACH** fee), then pays charities. `Completed` = recorded, not settled.
- ⚠️ Fund a payment method in the Pledge Impact Hub (sandbox done w/ Stripe test card; **prod TODO**).
- ⚠️ Charity nets ~92% → website "100% to charity" copy must be reworded ([subtask 86ey3amud](https://app.clickup.com/t/86ey3amud)).
- ⚠️ Re-sync charity catalog from staging post-deploy (org IDs); rotate the exposed prod Pledge key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added charity payout/disbursement workflow that groups eligible penalties into payouts by charity and currency.
  * Added background processing to claim pending payouts, create donations, and mark payouts as completed/failed safely.
  * Added reconciliation by matching previously recorded vendor donations to prevent duplicate processing.
  * Added an admin endpoint to run the payout process on demand.
* **Configuration**
  * Introduced Disbursement settings (enabled flag, minimum payout, batch limits, donor identity) with safe-environment guidance.
* **Documentation**
  * Updated developer documentation with end-to-end payout flow details.
* **Tests**
  * Added unit and database-backed integration tests for the disbursement flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->