### PR TITLE
fix: don't consume a freeze credit on a vacation day

### DIFF
--- a/Domain/Habit/Service.cs
+++ b/Domain/Habit/Service.cs
@@ -73,16 +73,21 @@ public class HabitService(
 
     // 3) For users on vacation today, insert Vacation executions for their active versions
     var totalProtected = 0;
+    var usersOnVacation = new HashSet<string>();
     foreach (var kv in hvByUser)
     {
       var userId = kv.Key;
       var hvIds = kv.Value;
       var vacations = await vacationRepo.ListActiveForUserOnDate(userId, date);
       var vs = (List<VacationPrincipal>)vacations;
-      if (vs.Count > 0 && hvIds.Count > 0)
+      if (vs.Count > 0)
       {
-        var inserted = await repo.CreateExecutionsForVersionsWithStatus(hvIds, date, ExecutionStatus.Vacation);
-        totalProtected += (int)inserted;
+        usersOnVacation.Add(userId);
+        if (hvIds.Count > 0)
+        {
+          var inserted = await repo.CreateExecutionsForVersionsWithStatus(hvIds, date, ExecutionStatus.Vacation);
+          totalProtected += (int)inserted;
+        }
       }
     }
 
@@ -94,6 +99,11 @@ public class HabitService(
       var userId = kv.Key;
       var hvIds = kv.Value;
       if (hvIds.Count == 0) continue;
+
+      // Vacation already protects every scheduled habit for this user today, so a
+      // freeze would only no-op on the anti-join while still burning a credit.
+      // Skip the freeze branch entirely for vacationing users.
+      if (usersOnVacation.Contains(userId)) continue;
 
       var anyDone = await repo.HasAnyCompletedOrSkippedForVersions(hvIds, date);
       if (anyDone)

--- a/UnitTest/Protection/Fakes.cs
+++ b/UnitTest/Protection/Fakes.cs
@@ -158,7 +158,7 @@ public sealed class FakeHabitRepository(CallLog? log = null) : IHabitRepository
 
   public Task<Result<List<Guid>>> GetEnabledHabitIdsByTimezone(string timezone)
   {
-    var ids = HabitIdsByTimezone.TryGetValue(timezone, out var x) ? x.ToList() : new List<Guid>();
+    var ids = HabitIdsByTimezone.TryGetValue(timezone, out var x) ? x.ToList() : [];
     return Task.FromResult<Result<List<Guid>>>(ids);
   }
 
@@ -234,7 +234,7 @@ public sealed class FakeVacationRepository : IVacationRepository
     ListActiveForUserOnDateCalls.Add((userId, date));
     var list = ActiveByUser.TryGetValue(userId, out var v)
       ? v.Where(x => x.Record.StartDate <= date && date <= x.Record.EndDate).ToList()
-      : new List<VacationPrincipal>();
+      : [];
     return Task.FromResult<Result<List<VacationPrincipal>>>(list);
   }
 

--- a/UnitTest/Protection/Fakes.cs
+++ b/UnitTest/Protection/Fakes.cs
@@ -1,0 +1,413 @@
+using CSharp_Result;
+using Domain.Entitlement;
+using Domain.Habit;
+using Domain.Protection;
+using Domain.Vacation;
+
+namespace UnitTest.Protection;
+
+// Shared hand-rolled fakes (no Moq) for unit-testing the Domain HabitService
+// skip / freeze / vacation / daily-failure-cron paths. Every method on the
+// faked interfaces is implemented; members not exercised by SkipHabit,
+// CompleteHabit or MarkDailyFailures(...) throw NotImplementedException, while
+// the ones that ARE exercised are backed by simple, seedable, inspectable
+// in-memory state.
+//
+// A single shared monotonically-increasing "call sequence" lets ordering tests
+// assert that Vacation inserts precede Freeze inserts precede the Fail step.
+
+public sealed class CallLog
+{
+  private int _seq;
+  public int Next() => ++_seq;
+}
+
+// ---------------------------------------------------------------------------
+// IHabitRepository
+// ---------------------------------------------------------------------------
+//
+// Seedable state:
+//   ActiveVersions          -> returned by GetActiveHabitVersionsByIds
+//   Habits                  -> returned by GetHabitsByIds (and GetHabit)
+//   CompletedOrSkipped      -> set of habitVersionIds considered "done"
+//                              (drives HasAnyCompletedOrSkippedForVersions)
+//   ExistingExecutions      -> set of (habitVersionId, date) that already have
+//                              an execution row of ANY status. Seed this to
+//                              model Completed/Skipped/Vacation/Freeze/Failed
+//                              rows so the in-memory CreateFailedExecutions and
+//                              CreateExecutionsForVersionsWithStatus anti-joins
+//                              skip them, exactly like the real SQL LEFT JOIN.
+//   FailedRowTemplates      -> map habitVersionId -> FailedExecutionRow factory
+//                              data used to build the rows CreateFailedExecutions
+//                              returns for versions that are scheduled today and
+//                              have NO existing execution.
+//   CurrentDate             -> returned by GetUserCurrentDate (skip/complete)
+//   Timezones / HabitIdsByTimezone -> drive the cron entrypoint
+//
+// Inspectable state (recorded calls, each tagged with a sequence number):
+//   CreateExecutionsForVersionsWithStatusCalls
+//   CreateFailedExecutionsCalls
+//   HasAnyCompletedOrSkippedCalls
+//   SkipHabitCalls / CompleteHabitCalls
+public sealed class FakeHabitRepository(CallLog? log = null) : IHabitRepository
+{
+  private readonly CallLog _log = log ?? new CallLog();
+
+  // ----- seedable inputs -----
+  public List<HabitVersionPrincipal> ActiveVersions { get; } = [];
+  public List<HabitPrincipal> Habits { get; } = [];
+  public HashSet<Guid> CompletedOrSkipped { get; } = [];
+  public HashSet<(Guid HabitVersionId, DateOnly Date)> ExistingExecutions { get; } = [];
+
+  // For each scheduled habitVersionId that truly misses, what FailedExecutionRow
+  // should CreateFailedExecutions produce. ExecutionId/UserId/CharityId/stake/etc.
+  public Dictionary<Guid, FailedRowSeed> FailedRowSeeds { get; } = [];
+
+  public DateOnly CurrentDate { get; set; } = new(2026, 1, 1);
+  public List<string> Timezones { get; } = [];
+  public Dictionary<string, List<Guid>> HabitIdsByTimezone { get; } = [];
+
+  // ----- recorded calls (inspectable) -----
+  public List<(int Seq, List<Guid> HvIds, DateOnly Date, ExecutionStatus Status)> CreateExecutionsForVersionsWithStatusCalls { get; } = [];
+  public List<(int Seq, List<Guid> HabitIds, DateOnly Date, List<FailedExecutionRow> Returned)> CreateFailedExecutionsCalls { get; } = [];
+  public List<(int Seq, List<Guid> HvIds, DateOnly Date)> HasAnyCompletedOrSkippedCalls { get; } = [];
+  public List<(string UserId, Guid HabitVersionId, DateOnly Date, string? Notes)> SkipHabitCalls { get; } = [];
+  public List<(string UserId, Guid HabitVersionId, DateOnly Date, string? Notes)> CompleteHabitCalls { get; } = [];
+
+  // ---- methods exercised by MarkDailyFailures / Skip / Complete ----
+
+  public Task<Result<List<HabitVersionPrincipal>>> GetActiveHabitVersionsByIds(List<Guid> habitIds, DateOnly date)
+  {
+    var hs = habitIds.ToHashSet();
+    var result = ActiveVersions.Where(v => hs.Contains(v.HabitId)).ToList();
+    return Task.FromResult<Result<List<HabitVersionPrincipal>>>(result);
+  }
+
+  public Task<Result<List<HabitPrincipal>>> GetHabitsByIds(List<Guid> habitIds)
+  {
+    var hs = habitIds.ToHashSet();
+    var result = Habits.Where(h => hs.Contains(h.Id)).ToList();
+    return Task.FromResult<Result<List<HabitPrincipal>>>(result);
+  }
+
+  public Task<Result<bool>> HasAnyCompletedOrSkippedForVersions(List<Guid> habitVersionIds, DateOnly date)
+  {
+    HasAnyCompletedOrSkippedCalls.Add((_log.Next(), habitVersionIds, date));
+    var any = habitVersionIds.Any(CompletedOrSkipped.Contains);
+    return Task.FromResult<Result<bool>>(any);
+  }
+
+  public Task<Result<int>> CreateExecutionsForVersionsWithStatus(List<Guid> habitVersionIds, DateOnly date, ExecutionStatus status)
+  {
+    CreateExecutionsForVersionsWithStatusCalls.Add((_log.Next(), [.. habitVersionIds], date, status));
+    // Mimic the real anti-join: only insert where no execution exists yet for
+    // (version, date). Record the freshly inserted rows so subsequent inserts /
+    // the fail step see them as existing.
+    var inserted = 0;
+    foreach (var hv in habitVersionIds)
+    {
+      if (ExistingExecutions.Add((hv, date))) inserted++;
+    }
+    return Task.FromResult<Result<int>>(inserted);
+  }
+
+  public Task<Result<List<FailedExecutionRow>>> CreateFailedExecutions(List<Guid> habitIds, DateOnly date)
+  {
+    var seq = _log.Next();
+    var hs = habitIds.ToHashSet();
+    var rows = new List<FailedExecutionRow>();
+
+    // Anti-join semantics: only fail a scheduled version that has NO existing
+    // execution row for that date (so completed / skipped / vacation / frozen
+    // rows — modelled via ExistingExecutions — are excluded).
+    foreach (var v in ActiveVersions)
+    {
+      if (!hs.Contains(v.HabitId)) continue;
+      if (ExistingExecutions.Contains((v.Id, date))) continue;
+      if (!FailedRowSeeds.TryGetValue(v.Id, out var seed)) continue;
+
+      ExistingExecutions.Add((v.Id, date)); // a Failed row now occupies the slot
+      rows.Add(seed.ToRow());
+    }
+
+    CreateFailedExecutionsCalls.Add((seq, [.. habitIds], date, rows));
+    return Task.FromResult<Result<List<FailedExecutionRow>>>(rows);
+  }
+
+  public Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId)
+    => Task.FromResult<Result<DateOnly>>(CurrentDate);
+
+  public Task<Result<HabitExecutionPrincipal>> SkipHabit(string userId, Guid habitVersionId, DateOnly date, string? notes)
+  {
+    SkipHabitCalls.Add((userId, habitVersionId, date, notes));
+    return Task.FromResult<Result<HabitExecutionPrincipal>>(
+      MakeExecution(habitVersionId, date, ExecutionStatus.Skipped, notes));
+  }
+
+  public Task<Result<HabitExecutionPrincipal>> CompleteHabit(string userId, Guid habitVersionId, DateOnly date, string? notes)
+  {
+    CompleteHabitCalls.Add((userId, habitVersionId, date, notes));
+    return Task.FromResult<Result<HabitExecutionPrincipal>>(
+      MakeExecution(habitVersionId, date, ExecutionStatus.Completed, notes));
+  }
+
+  public Task<Result<List<string>>> GetDistinctTimezonesForEnabledHabits()
+    => Task.FromResult<Result<List<string>>>(Timezones.ToList());
+
+  public Task<Result<List<Guid>>> GetEnabledHabitIdsByTimezone(string timezone)
+  {
+    var ids = HabitIdsByTimezone.TryGetValue(timezone, out var x) ? x.ToList() : new List<Guid>();
+    return Task.FromResult<Result<List<Guid>>>(ids);
+  }
+
+  public Task<Result<HabitPrincipal?>> GetHabit(Guid habitId)
+    => Task.FromResult<Result<HabitPrincipal?>>(Habits.FirstOrDefault(h => h.Id == habitId));
+
+  private static HabitExecutionPrincipal MakeExecution(Guid hvId, DateOnly date, ExecutionStatus status, string? notes)
+    => new()
+    {
+      Id = Guid.NewGuid(),
+      HabitVersionId = hvId,
+      Record = new HabitExecutionRecord
+      {
+        Date = date,
+        Status = status,
+        CompletedAt = status == ExecutionStatus.Completed ? DateTime.UtcNow : null,
+        Notes = notes
+      }
+    };
+
+  // ---- members not exercised by the paths under test ----
+  public Task<Result<List<HabitVersionPrincipal>>> GetActiveHabitVersions(string userId, DateOnly date)
+    => throw new NotImplementedException();
+  public Task<Result<List<HabitVersionPrincipal>>> SearchHabits(HabitSearch habitSearch)
+    => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal?>> GetCurrentVersion(string userId, Guid habitId)
+    => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal>> Create(string userId, HabitVersionRecord versionRecord)
+    => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal?>> Update(Guid habitId, string userId, HabitVersionRecord versionRecord, bool enabled)
+    => throw new NotImplementedException();
+  public Task<Result<Unit?>> Delete(Guid habitId, string userId)
+    => throw new NotImplementedException();
+  public Task<Result<List<HabitExecutionPrincipal>>> SearchHabitExecutions(string userId, HabitExecutionSearch habitExecutionSearch)
+    => throw new NotImplementedException();
+  public Task<Result<List<HabitVersionPrincipal>>> GetVersions(string userId, Guid habitId)
+    => throw new NotImplementedException();
+  public Task<Result<int>> CountHabitsForUser(string userId)
+    => throw new NotImplementedException();
+  public Task<Result<int>> CountUserSkipsForMonth(string userId, DateOnly monthStart, DateOnly monthEnd)
+    => throw new NotImplementedException();
+}
+
+// Seed data for a Failed row produced by CreateFailedExecutions for a true miss.
+// amountCents in the service = StakeCents * RatioBasisPoints / 10000.
+public sealed record FailedRowSeed
+{
+  public Guid ExecutionId { get; init; } = Guid.NewGuid();
+  public required string UserId { get; init; }
+  public Guid CharityId { get; init; } = Guid.NewGuid();
+  public int StakeCents { get; init; } = 1000;        // $10.00
+  public string StakeCurrency { get; init; } = "USD";
+  public int RatioBasisPoints { get; init; } = 5000;  // 50%
+
+  public FailedExecutionRow ToRow()
+    => new(ExecutionId, UserId, CharityId, StakeCents, StakeCurrency, RatioBasisPoints);
+}
+
+// ---------------------------------------------------------------------------
+// IVacationRepository
+// ---------------------------------------------------------------------------
+//
+// Seedable state: ActiveByUser[userId] = list of VacationPrincipal active on the
+// queried date. ListActiveForUserOnDate returns it (the service only reads .Count).
+// Inspectable: ListActiveForUserOnDateCalls.
+public sealed class FakeVacationRepository : IVacationRepository
+{
+  public Dictionary<string, List<VacationPrincipal>> ActiveByUser { get; } = [];
+  public List<(string UserId, DateOnly Date)> ListActiveForUserOnDateCalls { get; } = [];
+
+  public Task<Result<List<VacationPrincipal>>> ListActiveForUserOnDate(string userId, DateOnly date)
+  {
+    ListActiveForUserOnDateCalls.Add((userId, date));
+    var list = ActiveByUser.TryGetValue(userId, out var v) ? v.ToList() : new List<VacationPrincipal>();
+    return Task.FromResult<Result<List<VacationPrincipal>>>(list);
+  }
+
+  // Convenience: seed one active vacation window for a user.
+  public FakeVacationRepository WithActive(string userId, DateOnly start, DateOnly end, string timezone = "UTC")
+  {
+    if (!ActiveByUser.TryGetValue(userId, out var list))
+    {
+      list = [];
+      ActiveByUser[userId] = list;
+    }
+    list.Add(new VacationPrincipal
+    {
+      Id = Guid.NewGuid(),
+      UserId = userId,
+      Record = new VacationRecord { StartDate = start, EndDate = end, Timezone = timezone }
+    });
+    return this;
+  }
+
+  // ---- members not exercised by MarkDailyFailures ----
+  public Task<Result<VacationPrincipal?>> Get(Guid id) => throw new NotImplementedException();
+  public Task<Result<VacationPrincipal?>> Get(Guid id, string? userId) => throw new NotImplementedException();
+  public Task<Result<VacationPrincipal>> Create(string userId, VacationRecord record) => throw new NotImplementedException();
+  public Task<Result<VacationPrincipal?>> Update(Guid id, VacationRecord record) => throw new NotImplementedException();
+  public Task<Result<Unit?>> Delete(Guid id, string userId) => throw new NotImplementedException();
+  public Task<Result<List<VacationPrincipal>>> Search(VacationSearch search) => throw new NotImplementedException();
+  public Task<Result<int>> CountWindowsForYear(string userId, int year) => throw new NotImplementedException();
+  public Task<Result<bool>> HasOverlap(string userId, DateOnly start, DateOnly end) => throw new NotImplementedException();
+}
+
+// ---------------------------------------------------------------------------
+// IProtectionRepository
+// ---------------------------------------------------------------------------
+//
+// Freeze balance / cap model:
+//   FreezeBalance is the in-memory pool. TryConsumeFreeze decrements it by 1 and
+//   returns true while > 0; returns false (no decrement) at 0. It is idempotent
+//   per date: a date already consumed returns true WITHOUT decrementing again.
+// Inspectable: TryConsumeFreezeCalls, ConsumedDates, IncrementFreezeCalls,
+//   ClampFreezeToCapCalls, RecordFreezeAwardIfAbsentCalls.
+public sealed class FakeProtectionRepository(int freezeBalance = 0) : IProtectionRepository
+{
+  public int FreezeBalance { get; set; } = freezeBalance;
+
+  public List<(string UserId, DateOnly Date)> TryConsumeFreezeCalls { get; } = [];
+  public HashSet<(string UserId, DateOnly Date)> ConsumedDates { get; } = [];
+  public List<(string UserId, int N)> IncrementFreezeCalls { get; } = [];
+  public List<(string UserId, int Cap)> ClampFreezeToCapCalls { get; } = [];
+  public List<(Guid HabitId, DateOnly WeekStart)> RecordFreezeAwardIfAbsentCalls { get; } = [];
+  public HashSet<(Guid HabitId, DateOnly WeekStart)> AwardLedger { get; } = [];
+
+  public Task<Result<bool>> TryConsumeFreeze(string userId, DateOnly date)
+  {
+    TryConsumeFreezeCalls.Add((userId, date));
+    // Idempotent per date: already consumed -> true, no further decrement.
+    if (ConsumedDates.Contains((userId, date)))
+      return Task.FromResult<Result<bool>>(true);
+    if (FreezeBalance <= 0)
+      return Task.FromResult<Result<bool>>(false);
+    FreezeBalance -= 1;
+    ConsumedDates.Add((userId, date));
+    return Task.FromResult<Result<bool>>(true);
+  }
+
+  public Task<Result<Unit>> IncrementFreeze(string userId, int n)
+  {
+    IncrementFreezeCalls.Add((userId, n));
+    FreezeBalance += Math.Max(0, n); // cap-blind, like the real repo
+    return Task.FromResult<Result<Unit>>(new Unit());
+  }
+
+  public Task<Result<Unit>> ClampFreezeToCap(string userId, int cap)
+  {
+    ClampFreezeToCapCalls.Add((userId, cap));
+    if (FreezeBalance > cap) FreezeBalance = cap;
+    return Task.FromResult<Result<Unit>>(new Unit());
+  }
+
+  public Task<Result<bool>> RecordFreezeAwardIfAbsent(Guid habitId, DateOnly weekStart)
+  {
+    RecordFreezeAwardIfAbsentCalls.Add((habitId, weekStart));
+    var added = AwardLedger.Add((habitId, weekStart));
+    return Task.FromResult<Result<bool>>(added);
+  }
+
+  public Task<Result<UserProtectionPrincipal?>> GetProtection(string userId)
+    => Task.FromResult<Result<UserProtectionPrincipal?>>(new UserProtectionPrincipal
+    {
+      UserId = userId,
+      Record = new UserProtectionRecord { FreezeCurrent = FreezeBalance }
+    });
+
+  public Task<Result<UserProtectionPrincipal>> UpsertProtection(string userId)
+    => Task.FromResult<Result<UserProtectionPrincipal>>(new UserProtectionPrincipal
+    {
+      UserId = userId,
+      Record = new UserProtectionRecord { FreezeCurrent = FreezeBalance }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// IEntitlementService
+// ---------------------------------------------------------------------------
+//
+// Not exercised by MarkDailyFailures / SkipHabit / CompleteHabit, but the
+// HabitService ctor requires it. Configurable so it can also be reused for
+// skip/vacation/freeze entitlement tests.
+//   EnsureSkipsAllowedResult / EnsureVacationWindowAllowedResult /
+//   EnsureHabitsAllowedResult  -> the Result<Unit> each Ensure* returns.
+//   FreezeCap                  -> the int GetFreezeCapForUser returns.
+public sealed class FakeEntitlementService : IEntitlementService
+{
+  public Result<Unit> EnsureSkipsAllowedResult { get; set; } = new Unit();
+  public Result<Unit> EnsureVacationWindowAllowedResult { get; set; } = new Unit();
+  public Result<Unit> EnsureHabitsAllowedResult { get; set; } = new Unit();
+  public int FreezeCap { get; set; } = 7;
+
+  public List<(string UserId, DateOnly MonthStart, DateOnly MonthEnd)> EnsureSkipsAllowedCalls { get; } = [];
+  public List<(string UserId, DateOnly StartDate)> EnsureVacationWindowAllowedCalls { get; } = [];
+  public List<(string UserId, int UserMaxStreak)> GetFreezeCapForUserCalls { get; } = [];
+  public List<string> EnsureHabitsAllowedCalls { get; } = [];
+
+  public Task<Result<Unit>> EnsureSkipsAllowed(string userId, DateOnly monthStart, DateOnly monthEnd)
+  {
+    EnsureSkipsAllowedCalls.Add((userId, monthStart, monthEnd));
+    return Task.FromResult(EnsureSkipsAllowedResult);
+  }
+
+  public Task<Result<Unit>> EnsureVacationWindowAllowed(string userId, DateOnly startDate)
+  {
+    EnsureVacationWindowAllowedCalls.Add((userId, startDate));
+    return Task.FromResult(EnsureVacationWindowAllowedResult);
+  }
+
+  public Task<Result<int>> GetFreezeCapForUser(string userId, int userMaxStreak)
+  {
+    GetFreezeCapForUserCalls.Add((userId, userMaxStreak));
+    return Task.FromResult<Result<int>>(FreezeCap);
+  }
+
+  public Task<Result<Unit>> EnsureHabitsAllowed(string userId)
+  {
+    EnsureHabitsAllowedCalls.Add(userId);
+    return Task.FromResult(EnsureHabitsAllowedResult);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Builders for the domain principals tests need to seed.
+// ---------------------------------------------------------------------------
+public static class HabitFakeFactory
+{
+  public static HabitPrincipal Habit(Guid id, string userId, ushort version = 1, bool enabled = true)
+    => new()
+    {
+      Id = id,
+      UserId = userId,
+      Record = new HabitRecord { Version = version, Enabled = enabled }
+    };
+
+  public static HabitVersionPrincipal Version(Guid id, Guid habitId, ushort version = 1,
+    string timezone = "UTC", string[]? daysOfWeek = null)
+    => new()
+    {
+      Id = id,
+      HabitId = habitId,
+      Version = version,
+      Record = new HabitVersionRecord
+      {
+        CharityId = Guid.NewGuid(),
+        Task = "task",
+        DaysOfWeek = daysOfWeek ?? ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        NotificationTime = new TimeOnly(9, 0),
+        Stake = new NodaMoney.Money(10m, NodaMoney.Currency.FromCode("USD")),
+        Ratio = 0.5m,
+        Timezone = timezone
+      }
+    };
+}

--- a/UnitTest/Protection/Fakes.cs
+++ b/UnitTest/Protection/Fakes.cs
@@ -29,8 +29,10 @@ public sealed class CallLog
 // Seedable state:
 //   ActiveVersions          -> returned by GetActiveHabitVersionsByIds
 //   Habits                  -> returned by GetHabitsByIds (and GetHabit)
-//   CompletedOrSkipped      -> set of habitVersionIds considered "done"
-//                              (drives HasAnyCompletedOrSkippedForVersions)
+//   CompletedOrSkipped      -> set of (habitVersionId, date) considered "done"
+//                              (drives HasAnyCompletedOrSkippedForVersions);
+//                              date-scoped so a completion on one day does not
+//                              leak into other days.
 //   ExistingExecutions      -> set of (habitVersionId, date) that already have
 //                              an execution row of ANY status. Seed this to
 //                              model Completed/Skipped/Vacation/Freeze/Failed
@@ -56,7 +58,7 @@ public sealed class FakeHabitRepository(CallLog? log = null) : IHabitRepository
   // ----- seedable inputs -----
   public List<HabitVersionPrincipal> ActiveVersions { get; } = [];
   public List<HabitPrincipal> Habits { get; } = [];
-  public HashSet<Guid> CompletedOrSkipped { get; } = [];
+  public HashSet<(Guid HabitVersionId, DateOnly Date)> CompletedOrSkipped { get; } = [];
   public HashSet<(Guid HabitVersionId, DateOnly Date)> ExistingExecutions { get; } = [];
 
   // For each scheduled habitVersionId that truly misses, what FailedExecutionRow
@@ -93,7 +95,7 @@ public sealed class FakeHabitRepository(CallLog? log = null) : IHabitRepository
   public Task<Result<bool>> HasAnyCompletedOrSkippedForVersions(List<Guid> habitVersionIds, DateOnly date)
   {
     HasAnyCompletedOrSkippedCalls.Add((_log.Next(), habitVersionIds, date));
-    var any = habitVersionIds.Any(CompletedOrSkipped.Contains);
+    var any = habitVersionIds.Any(hvId => CompletedOrSkipped.Contains((hvId, date)));
     return Task.FromResult<Result<bool>>(any);
   }
 
@@ -230,7 +232,9 @@ public sealed class FakeVacationRepository : IVacationRepository
   public Task<Result<List<VacationPrincipal>>> ListActiveForUserOnDate(string userId, DateOnly date)
   {
     ListActiveForUserOnDateCalls.Add((userId, date));
-    var list = ActiveByUser.TryGetValue(userId, out var v) ? v.ToList() : new List<VacationPrincipal>();
+    var list = ActiveByUser.TryGetValue(userId, out var v)
+      ? v.Where(x => x.Record.StartDate <= date && date <= x.Record.EndDate).ToList()
+      : new List<VacationPrincipal>();
     return Task.FromResult<Result<List<VacationPrincipal>>>(list);
   }
 
@@ -267,14 +271,21 @@ public sealed class FakeVacationRepository : IVacationRepository
 // ---------------------------------------------------------------------------
 //
 // Freeze balance / cap model:
-//   FreezeBalance is the in-memory pool. TryConsumeFreeze decrements it by 1 and
-//   returns true while > 0; returns false (no decrement) at 0. It is idempotent
-//   per date: a date already consumed returns true WITHOUT decrementing again.
+//   The freeze pool is PER USER (mirrors the real UserProtections row keyed by
+//   userId), held in a dictionary that lazily defaults to the ctor seed on first
+//   touch. Use BalanceFor(userId) to read and SetBalanceFor(userId, n) to seed a
+//   specific user. TryConsumeFreeze decrements that user's pool by 1 and returns
+//   true while > 0; returns false (no decrement) at 0. It is idempotent per date:
+//   a date already consumed returns true WITHOUT decrementing again.
 // Inspectable: TryConsumeFreezeCalls, ConsumedDates, IncrementFreezeCalls,
 //   ClampFreezeToCapCalls, RecordFreezeAwardIfAbsentCalls.
 public sealed class FakeProtectionRepository(int freezeBalance = 0) : IProtectionRepository
 {
-  public int FreezeBalance { get; set; } = freezeBalance;
+  private readonly Dictionary<string, int> _balances = [];
+
+  // Per-user freeze pool, lazily seeded from the ctor default on first read.
+  public int BalanceFor(string userId) => _balances.TryGetValue(userId, out var b) ? b : freezeBalance;
+  public void SetBalanceFor(string userId, int balance) => _balances[userId] = balance;
 
   public List<(string UserId, DateOnly Date)> TryConsumeFreezeCalls { get; } = [];
   public HashSet<(string UserId, DateOnly Date)> ConsumedDates { get; } = [];
@@ -289,9 +300,9 @@ public sealed class FakeProtectionRepository(int freezeBalance = 0) : IProtectio
     // Idempotent per date: already consumed -> true, no further decrement.
     if (ConsumedDates.Contains((userId, date)))
       return Task.FromResult<Result<bool>>(true);
-    if (FreezeBalance <= 0)
+    if (BalanceFor(userId) <= 0)
       return Task.FromResult<Result<bool>>(false);
-    FreezeBalance -= 1;
+    SetBalanceFor(userId, BalanceFor(userId) - 1);
     ConsumedDates.Add((userId, date));
     return Task.FromResult<Result<bool>>(true);
   }
@@ -299,14 +310,14 @@ public sealed class FakeProtectionRepository(int freezeBalance = 0) : IProtectio
   public Task<Result<Unit>> IncrementFreeze(string userId, int n)
   {
     IncrementFreezeCalls.Add((userId, n));
-    FreezeBalance += Math.Max(0, n); // cap-blind, like the real repo
+    SetBalanceFor(userId, BalanceFor(userId) + Math.Max(0, n)); // cap-blind, like the real repo
     return Task.FromResult<Result<Unit>>(new Unit());
   }
 
   public Task<Result<Unit>> ClampFreezeToCap(string userId, int cap)
   {
     ClampFreezeToCapCalls.Add((userId, cap));
-    if (FreezeBalance > cap) FreezeBalance = cap;
+    if (BalanceFor(userId) > cap) SetBalanceFor(userId, cap);
     return Task.FromResult<Result<Unit>>(new Unit());
   }
 
@@ -321,14 +332,14 @@ public sealed class FakeProtectionRepository(int freezeBalance = 0) : IProtectio
     => Task.FromResult<Result<UserProtectionPrincipal?>>(new UserProtectionPrincipal
     {
       UserId = userId,
-      Record = new UserProtectionRecord { FreezeCurrent = FreezeBalance }
+      Record = new UserProtectionRecord { FreezeCurrent = BalanceFor(userId) }
     });
 
   public Task<Result<UserProtectionPrincipal>> UpsertProtection(string userId)
     => Task.FromResult<Result<UserProtectionPrincipal>>(new UserProtectionPrincipal
     {
       UserId = userId,
-      Record = new UserProtectionRecord { FreezeCurrent = FreezeBalance }
+      Record = new UserProtectionRecord { FreezeCurrent = BalanceFor(userId) }
     });
 }
 

--- a/UnitTest/Protection/FreezeCapTests.cs
+++ b/UnitTest/Protection/FreezeCapTests.cs
@@ -1,0 +1,283 @@
+using CSharp_Result;
+using Domain.Habit;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaMoney;
+using UnitTest.Penalty;
+
+namespace UnitTest.Protection;
+
+// Unit tests for the FREEZE protection lifecycle that is reachable from the
+// Domain layer with the shared hand-rolled fakes:
+//
+//   * CONSUME  -> HabitService.MarkDailyFailures step 4: a user with a freeze
+//                 day available and nothing completed/skipped today gets all
+//                 their scheduled versions marked Frozen, the user-level pool
+//                 is decremented by exactly one, and those versions are then
+//                 excluded from the Fail step (no penalty).
+//   * CAP      -> IProtectionRepository increment-then-clamp mechanics
+//                 (IncrementFreeze is cap-blind; ClampFreezeToCap is the cap
+//                 enforcer) plus FreezePolicy.ComputeFreezeMax cap derivation.
+//
+// The cap is parameterized via [Theory] so these stay valid when the
+// per-subscription-tier base cap / streak bonuses change.
+//
+// NOTE ON SCOPE: the *award* orchestration (perfect-week detection ->
+// RecordFreezeAwardIfAbsent -> IncrementFreeze -> GetFreezeCapForUser ->
+// ClampFreezeToCap) lives in App.Modules.Protection.ProtectionAwardService,
+// which resolves IConfigurationService / IStreakService / IStreakRepository
+// through an IServiceProvider scope. Those collaborators are NOT covered by
+// the shared Protection fakes, so the end-to-end award-then-clamp flow is
+// reported in needsIntegration rather than faked into a green unit test. Here
+// we unit-test the repo-level cap contract the award flow relies on.
+public class FreezeCapTests
+{
+  private const string UserId = "user-freeze-1";
+  private static readonly DateOnly Date = new(2026, 1, 15);
+
+  private static HabitService Build(
+    FakeHabitRepository repo,
+    FakeVacationRepository vac,
+    FakeProtectionRepository prot,
+    FakePenaltyRepository penalty,
+    FakeEntitlementService? ent = null)
+    => new(repo, vac, prot, ent ?? new FakeEntitlementService(), penalty,
+      NullLogger<HabitService>.Instance);
+
+  // Seed one scheduled habit (owned by UserId) that misses today unless a
+  // protection (vacation/freeze) intervenes.
+  private static (FakeHabitRepository repo, Guid habitId, Guid hvId) SeedScheduledMiss(
+    CallLog log, string userId = UserId)
+  {
+    var habitId = Guid.NewGuid();
+    var hvId = Guid.NewGuid();
+    var repo = new FakeHabitRepository(log);
+    repo.Habits.Add(HabitFakeFactory.Habit(habitId, userId));
+    repo.ActiveVersions.Add(HabitFakeFactory.Version(hvId, habitId));
+    repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = userId };
+    return (repo, habitId, hvId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // CONSUME — happy path
+  // ---------------------------------------------------------------------------
+
+  [Theory]
+  [InlineData(1)] // exactly one day in the pool
+  [InlineData(3)] // a larger pool: still only ONE day consumed for one date
+  [InlineData(7)] // a full tier cap worth of days
+  public async Task Consume_FreezeAvailable_MarksFrozen_DecrementsByOne_NoPenalty(int balance)
+  {
+    var log = new CallLog();
+    var (repo, habitId, hvId) = SeedScheduledMiss(log);
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: balance);
+    var penalty = new FakePenaltyRepository();
+    var svc = Build(repo, vac, prot, penalty);
+
+    var res = await svc.MarkDailyFailures([habitId], Date);
+
+    res.IsSuccess().Should().BeTrue();
+    // 0 failed + 0 vacation + 1 frozen
+    ((int)res).Should().Be(1);
+
+    // Exactly one freeze day consumed for this (user, date).
+    prot.TryConsumeFreezeCalls.Should().ContainSingle()
+      .Which.Should().Be((UserId, Date));
+    prot.FreezeBalance.Should().Be(balance - 1, "exactly one freeze day is consumed per protected date");
+    prot.ConsumedDates.Should().Contain((UserId, Date));
+
+    // A Frozen execution row was created for the scheduled version.
+    var freezeInserts = repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze).ToList();
+    freezeInserts.Should().ContainSingle();
+    freezeInserts[0].HvIds.Should().ContainSingle().Which.Should().Be(hvId);
+    freezeInserts[0].Date.Should().Be(Date);
+
+    // The frozen version is excluded from the Fail step => no Failed row, no penalty.
+    repo.CreateFailedExecutionsCalls.Should().ContainSingle();
+    repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Consume_IsIdempotentPerDate_SecondRunDoesNotDecrementAgain()
+  {
+    var log = new CallLog();
+    var (repo, habitId, _) = SeedScheduledMiss(log);
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: 1);
+    var penalty = new FakePenaltyRepository();
+    var svc = Build(repo, vac, prot, penalty);
+
+    await svc.MarkDailyFailures([habitId], Date);
+    prot.FreezeBalance.Should().Be(0);
+
+    // Re-running the same date must not re-charge the pool (real repo is
+    // idempotent per (user,date) via the consumption ledger).
+    await svc.MarkDailyFailures([habitId], Date);
+
+    prot.FreezeBalance.Should().Be(0, "a date already frozen must not consume a second freeze day");
+    prot.TryConsumeFreezeCalls.Should().HaveCount(2);
+    penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // CONSUME — sad path
+  // ---------------------------------------------------------------------------
+
+  [Fact]
+  public async Task Consume_BalanceZero_NotConsumed_VersionFails_PenaltyEnqueued()
+  {
+    var log = new CallLog();
+    var (repo, habitId, _) = SeedScheduledMiss(log);
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: 0);
+    var penalty = new FakePenaltyRepository();
+    var svc = Build(repo, vac, prot, penalty);
+
+    var res = await svc.MarkDailyFailures([habitId], Date);
+
+    res.IsSuccess().Should().BeTrue();
+    ((int)res).Should().Be(1); // 1 failed + 0 vacation + 0 frozen
+
+    // TryConsumeFreeze was attempted but returned false => no decrement, no freeze row.
+    prot.TryConsumeFreezeCalls.Should().ContainSingle();
+    prot.FreezeBalance.Should().Be(0);
+    prot.ConsumedDates.Should().BeEmpty();
+    repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze)
+      .Should().BeEmpty("a zero balance must not create any Frozen executions");
+
+    // Version actually failed => penalty enqueued (1000c * 5000bps = $5.00).
+    repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+    penalty.EnqueuedRecords.Should().ContainSingle()
+      .Which.Amount.Should().Be(new Money(5.00m, Currency.FromCode("USD")));
+  }
+
+  [Fact]
+  public async Task Consume_AlreadyCompletedOrSkipped_ShortCircuits_NoConsumeAttempt()
+  {
+    var log = new CallLog();
+    var (repo, habitId, hvId) = SeedScheduledMiss(log);
+    // Model a completed/skipped day: short-circuits the freeze branch AND
+    // occupies the slot so the fail step skips it.
+    repo.CompletedOrSkipped.Add(hvId);
+    repo.ExistingExecutions.Add((hvId, Date));
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: 5);
+    var penalty = new FakePenaltyRepository();
+    var svc = Build(repo, vac, prot, penalty);
+
+    var res = await svc.MarkDailyFailures([habitId], Date);
+
+    ((int)res).Should().Be(0);
+    prot.TryConsumeFreezeCalls.Should().BeEmpty("a completed/skipped day must never spend a freeze");
+    prot.FreezeBalance.Should().Be(5);
+    penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // CONSUME — depletion across distinct dates (cannot exceed what's in the pool)
+  // ---------------------------------------------------------------------------
+
+  [Theory]
+  [InlineData(1)]
+  [InlineData(2)]
+  [InlineData(7)]
+  public async Task Consume_AcrossDistinctDates_CannotExceedPool_ExcessDatesFail(int balance)
+  {
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: balance);
+    var penalty = new FakePenaltyRepository();
+
+    // Run one more day than the pool can cover.
+    var attempts = balance + 1;
+    var frozenDays = 0;
+    var failedDays = 0;
+
+    for (var i = 0; i < attempts; i++)
+    {
+      var log = new CallLog();
+      var (repo, habitId, _) = SeedScheduledMiss(log);
+      var svc = Build(repo, vac, prot, penalty);
+      var date = Date.AddDays(i);
+
+      await svc.MarkDailyFailures([habitId], date);
+
+      var frozeToday = repo.CreateExecutionsForVersionsWithStatusCalls
+        .Any(c => c.Status == ExecutionStatus.Freeze);
+      if (frozeToday) frozenDays++;
+      if (repo.CreateFailedExecutionsCalls[0].Returned.Count > 0) failedDays++;
+    }
+
+    // Pool covers exactly `balance` distinct dates; the extra date must fail.
+    frozenDays.Should().Be(balance);
+    failedDays.Should().Be(attempts - balance);
+    prot.FreezeBalance.Should().Be(0);
+    // One penalty per failed (excess) date.
+    penalty.EnqueuedRecords.Should().HaveCount(attempts - balance);
+  }
+
+  // ---------------------------------------------------------------------------
+  // CAP — repo-level increment-then-clamp contract (what the award flow relies on)
+  // ---------------------------------------------------------------------------
+
+  [Theory]
+  [InlineData(0, 3, 3)] // start empty, award 3, cap 3 -> 3
+  [InlineData(2, 10, 5)] // award beyond cap -> clamped down to cap
+  [InlineData(5, 1, 7)] // award stays under cap -> not clamped
+  [InlineData(7, 4, 7)] // already at cap, award more -> clamped back to cap
+  public async Task Cap_IncrementThenClamp_NeverExceedsCap(int start, int award, int cap)
+  {
+    var prot = new FakeProtectionRepository(freezeBalance: start);
+
+    // Award is cap-blind...
+    var inc = await prot.IncrementFreeze(UserId, award);
+    inc.IsSuccess().Should().BeTrue();
+    prot.FreezeBalance.Should().Be(start + award, "IncrementFreeze must be cap-blind");
+
+    // ...then ClampFreezeToCap enforces the ceiling.
+    var clamp = await prot.ClampFreezeToCap(UserId, cap);
+    clamp.IsSuccess().Should().BeTrue();
+
+    var expected = Math.Min(start + award, cap);
+    prot.FreezeBalance.Should().Be(expected);
+    prot.FreezeBalance.Should().BeLessThanOrEqualTo(cap, "the freeze pool must never exceed the cap after clamping");
+
+    prot.IncrementFreezeCalls.Should().ContainSingle().Which.Should().Be((UserId, award));
+    prot.ClampFreezeToCapCalls.Should().ContainSingle().Which.Should().Be((UserId, cap));
+  }
+
+  [Fact]
+  public async Task Cap_ClampOnDowngrade_TrimsExistingBalanceToLowerCap()
+  {
+    // Simulate a subscription downgrade: balance was accumulated under a higher
+    // tier, the new (lower) cap must trim it.
+    var prot = new FakeProtectionRepository(freezeBalance: 10);
+
+    await prot.ClampFreezeToCap(UserId, cap: 3);
+
+    prot.FreezeBalance.Should().Be(3);
+  }
+
+  // ---------------------------------------------------------------------------
+  // CAP — award ledger idempotency (one freeze per habit/week, enforced by the
+  // RecordFreezeAwardIfAbsent ledger the award flow gates IncrementFreeze on)
+  // ---------------------------------------------------------------------------
+
+  [Fact]
+  public async Task Cap_AwardLedger_IsIdempotentPerHabitWeek()
+  {
+    var prot = new FakeProtectionRepository(freezeBalance: 0);
+    var habitId = Guid.NewGuid();
+    var weekStart = new DateOnly(2026, 1, 11); // a Sunday
+
+    var first = await prot.RecordFreezeAwardIfAbsent(habitId, weekStart);
+    var second = await prot.RecordFreezeAwardIfAbsent(habitId, weekStart);
+
+    ((bool)first).Should().BeTrue("the first award for a habit/week is recorded");
+    ((bool)second).Should().BeFalse("a duplicate award for the same habit/week must be rejected");
+    prot.RecordFreezeAwardIfAbsentCalls.Should().HaveCount(2);
+    prot.AwardLedger.Should().ContainSingle().Which.Should().Be((habitId, weekStart));
+  }
+}

--- a/UnitTest/Protection/FreezeCapTests.cs
+++ b/UnitTest/Protection/FreezeCapTests.cs
@@ -83,7 +83,7 @@ public class FreezeCapTests
     // Exactly one freeze day consumed for this (user, date).
     prot.TryConsumeFreezeCalls.Should().ContainSingle()
       .Which.Should().Be((UserId, Date));
-    prot.FreezeBalance.Should().Be(balance - 1, "exactly one freeze day is consumed per protected date");
+    prot.BalanceFor(UserId).Should().Be(balance - 1, "exactly one freeze day is consumed per protected date");
     prot.ConsumedDates.Should().Contain((UserId, Date));
 
     // A Frozen execution row was created for the scheduled version.
@@ -110,13 +110,13 @@ public class FreezeCapTests
     var svc = Build(repo, vac, prot, penalty);
 
     await svc.MarkDailyFailures([habitId], Date);
-    prot.FreezeBalance.Should().Be(0);
+    prot.BalanceFor(UserId).Should().Be(0);
 
     // Re-running the same date must not re-charge the pool (real repo is
     // idempotent per (user,date) via the consumption ledger).
     await svc.MarkDailyFailures([habitId], Date);
 
-    prot.FreezeBalance.Should().Be(0, "a date already frozen must not consume a second freeze day");
+    prot.BalanceFor(UserId).Should().Be(0, "a date already frozen must not consume a second freeze day");
     prot.TryConsumeFreezeCalls.Should().HaveCount(2);
     penalty.EnqueuedRecords.Should().BeEmpty();
   }
@@ -142,7 +142,7 @@ public class FreezeCapTests
 
     // TryConsumeFreeze was attempted but returned false => no decrement, no freeze row.
     prot.TryConsumeFreezeCalls.Should().ContainSingle();
-    prot.FreezeBalance.Should().Be(0);
+    prot.BalanceFor(UserId).Should().Be(0);
     prot.ConsumedDates.Should().BeEmpty();
     repo.CreateExecutionsForVersionsWithStatusCalls
       .Where(c => c.Status == ExecutionStatus.Freeze)
@@ -161,7 +161,7 @@ public class FreezeCapTests
     var (repo, habitId, hvId) = SeedScheduledMiss(log);
     // Model a completed/skipped day: short-circuits the freeze branch AND
     // occupies the slot so the fail step skips it.
-    repo.CompletedOrSkipped.Add(hvId);
+    repo.CompletedOrSkipped.Add((hvId, Date));
     repo.ExistingExecutions.Add((hvId, Date));
     var vac = new FakeVacationRepository();
     var prot = new FakeProtectionRepository(freezeBalance: 5);
@@ -172,7 +172,7 @@ public class FreezeCapTests
 
     ((int)res).Should().Be(0);
     prot.TryConsumeFreezeCalls.Should().BeEmpty("a completed/skipped day must never spend a freeze");
-    prot.FreezeBalance.Should().Be(5);
+    prot.BalanceFor(UserId).Should().Be(5);
     penalty.EnqueuedRecords.Should().BeEmpty();
   }
 
@@ -213,7 +213,7 @@ public class FreezeCapTests
     // Pool covers exactly `balance` distinct dates; the extra date must fail.
     frozenDays.Should().Be(balance);
     failedDays.Should().Be(attempts - balance);
-    prot.FreezeBalance.Should().Be(0);
+    prot.BalanceFor(UserId).Should().Be(0);
     // One penalty per failed (excess) date.
     penalty.EnqueuedRecords.Should().HaveCount(attempts - balance);
   }
@@ -234,15 +234,15 @@ public class FreezeCapTests
     // Award is cap-blind...
     var inc = await prot.IncrementFreeze(UserId, award);
     inc.IsSuccess().Should().BeTrue();
-    prot.FreezeBalance.Should().Be(start + award, "IncrementFreeze must be cap-blind");
+    prot.BalanceFor(UserId).Should().Be(start + award, "IncrementFreeze must be cap-blind");
 
     // ...then ClampFreezeToCap enforces the ceiling.
     var clamp = await prot.ClampFreezeToCap(UserId, cap);
     clamp.IsSuccess().Should().BeTrue();
 
     var expected = Math.Min(start + award, cap);
-    prot.FreezeBalance.Should().Be(expected);
-    prot.FreezeBalance.Should().BeLessThanOrEqualTo(cap, "the freeze pool must never exceed the cap after clamping");
+    prot.BalanceFor(UserId).Should().Be(expected);
+    prot.BalanceFor(UserId).Should().BeLessThanOrEqualTo(cap, "the freeze pool must never exceed the cap after clamping");
 
     prot.IncrementFreezeCalls.Should().ContainSingle().Which.Should().Be((UserId, award));
     prot.ClampFreezeToCapCalls.Should().ContainSingle().Which.Should().Be((UserId, cap));
@@ -257,7 +257,7 @@ public class FreezeCapTests
 
     await prot.ClampFreezeToCap(UserId, cap: 3);
 
-    prot.FreezeBalance.Should().Be(3);
+    prot.BalanceFor(UserId).Should().Be(3);
   }
 
   // ---------------------------------------------------------------------------

--- a/UnitTest/Protection/MarkDailyFailuresTests.cs
+++ b/UnitTest/Protection/MarkDailyFailuresTests.cs
@@ -191,7 +191,7 @@ public class MarkDailyFailuresTests
   public async Task VacationedUser_DoesNotConsumeFreeze()
   {
     var h = Build(freezeBalance: 1);
-    var (habitId, hvId) = SeedScheduled(h);
+    var (habitId, _) = SeedScheduled(h);
     var date = new DateOnly(2026, 1, 1);
     h.Vac.WithActive(UserId, new DateOnly(2025, 12, 30), new DateOnly(2026, 1, 5));
 

--- a/UnitTest/Protection/MarkDailyFailuresTests.cs
+++ b/UnitTest/Protection/MarkDailyFailuresTests.cs
@@ -98,7 +98,7 @@ public class MarkDailyFailuresTests
     var date = new DateOnly(2026, 1, 1);
 
     // model a completed/skipped row: short-circuit freeze AND occupy the slot.
-    h.Repo.CompletedOrSkipped.Add(hvId);
+    h.Repo.CompletedOrSkipped.Add((hvId, date));
     h.Repo.ExistingExecutions.Add((hvId, date));
     // A seed exists, but the anti-join must exclude it.
     h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId };
@@ -110,7 +110,7 @@ public class MarkDailyFailuresTests
     h.Penalty.EnqueuedRecords.Should().BeEmpty();
     // anyDone short-circuits before the freeze branch.
     h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
-    h.Prot.FreezeBalance.Should().Be(5); // untouched
+    h.Prot.BalanceFor(UserId).Should().Be(5); // untouched
   }
 
   // ---------------------------------------------------------------------------
@@ -152,7 +152,7 @@ public class MarkDailyFailuresTests
     ((int)res).Should().Be(1); // 1 freeze row inserted, 0 failed
 
     h.Prot.TryConsumeFreezeCalls.Should().ContainSingle();
-    h.Prot.FreezeBalance.Should().Be(0); // decremented
+    h.Prot.BalanceFor(UserId).Should().Be(0); // decremented
     h.Repo.CreateExecutionsForVersionsWithStatusCalls
       .Where(c => c.Status == ExecutionStatus.Freeze)
       .Should().ContainSingle();
@@ -199,7 +199,7 @@ public class MarkDailyFailuresTests
 
     // Correct behavior: the vacation already protects the day; freeze must be left intact.
     h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
-    h.Prot.FreezeBalance.Should().Be(1);
+    h.Prot.BalanceFor(UserId).Should().Be(1);
   }
 
   // ---------------------------------------------------------------------------

--- a/UnitTest/Protection/MarkDailyFailuresTests.cs
+++ b/UnitTest/Protection/MarkDailyFailuresTests.cs
@@ -1,0 +1,345 @@
+using CSharp_Result;
+using Domain.Habit;
+using Domain.Penalty;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaMoney;
+using UnitTest.Penalty;
+
+namespace UnitTest.Protection;
+
+// Unit tests for the mark-as-fail cron orchestration (HabitService.MarkDailyFailures):
+//   - protected statuses (completed/skipped/frozen/vacationed) are NOT failed
+//   - a true miss IS failed and enqueues exactly one Pending penalty
+//   - idempotent re-run does not double-enqueue
+//   - ratio=0 / stake=0 -> failed row recorded but NO penalty enqueued
+//   - ordering: vacation insert -> freeze insert -> fail step
+//
+// Uses the shared hand-rolled fakes in UnitTest/Protection/Fakes.cs and reuses
+// the existing UnitTest.Penalty.FakePenaltyRepository.
+public class MarkDailyFailuresTests
+{
+  private const string UserId = "user-1";
+
+  private sealed record Harness(
+    FakeHabitRepository Repo,
+    FakeVacationRepository Vac,
+    FakeProtectionRepository Prot,
+    FakeEntitlementService Ent,
+    FakePenaltyRepository Penalty,
+    HabitService Svc);
+
+  // Build a service wired to fresh fakes. freezeBalance configures the freeze pool.
+  private static Harness Build(int freezeBalance = 0)
+  {
+    var log = new CallLog();
+    var repo = new FakeHabitRepository(log);
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: freezeBalance);
+    var ent = new FakeEntitlementService();
+    var penalty = new FakePenaltyRepository();
+    var svc = new HabitService(repo, vac, prot, ent, penalty, NullLogger<HabitService>.Instance);
+    return new Harness(repo, vac, prot, ent, penalty, svc);
+  }
+
+  // Seed one habit + its scheduled version for `date` and return (habitId, hvId).
+  private static (Guid HabitId, Guid HvId) SeedScheduled(Harness h, string userId = UserId)
+  {
+    var habitId = Guid.NewGuid();
+    var hvId = Guid.NewGuid();
+    h.Repo.Habits.Add(HabitFakeFactory.Habit(habitId, userId));
+    h.Repo.ActiveVersions.Add(HabitFakeFactory.Version(hvId, habitId));
+    return (habitId, hvId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // HAPPY: a true miss IS failed and enqueues exactly one Pending penalty.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task TrueMiss_IsFailed_AndEnqueuesExactlyOnePendingPenalty()
+  {
+    var h = Build();
+    var (habitId, hvId) = SeedScheduled(h);
+    var execId = Guid.NewGuid();
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId, ExecutionId = execId };
+    var date = new DateOnly(2026, 1, 1);
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+    ((int)res).Should().Be(1); // 1 failed row, no protected/frozen
+
+    h.Repo.CreateFailedExecutionsCalls.Should().ContainSingle();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+    var rec = h.Penalty.EnqueuedRecords[0];
+    rec.HabitExecutionId.Should().Be(execId);
+    rec.UserId.Should().Be(UserId);
+    rec.Status.Should().Be(PenaltyStatus.Pending);
+    // 1000c * 5000bps / 10000 = 500c = $5.00 USD
+    rec.Amount.Should().Be(new Money(5.00m, Currency.FromCode("USD")));
+
+    // The freeze branch is probed for any not-done habit, but with an empty pool
+    // (freezeBalance: 0) nothing is consumed and no Freeze execution is inserted.
+    h.Prot.TryConsumeFreezeCalls.Should().ContainSingle();
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze)
+      .Should().BeEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // SAD: completed / skipped habit is NOT failed (no penalty, no freeze probe).
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task CompletedOrSkipped_IsNotFailed_AndDoesNotConsumeFreeze()
+  {
+    var h = Build(freezeBalance: 5);
+    var (habitId, hvId) = SeedScheduled(h);
+    var date = new DateOnly(2026, 1, 1);
+
+    // model a completed/skipped row: short-circuit freeze AND occupy the slot.
+    h.Repo.CompletedOrSkipped.Add(hvId);
+    h.Repo.ExistingExecutions.Add((hvId, date));
+    // A seed exists, but the anti-join must exclude it.
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId };
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(0);
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+    // anyDone short-circuits before the freeze branch.
+    h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
+    h.Prot.FreezeBalance.Should().Be(5); // untouched
+  }
+
+  // ---------------------------------------------------------------------------
+  // SAD: vacationed habit is NOT failed; a Vacation execution is inserted instead.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task Vacationed_IsNotFailed_AndInsertsVacationExecution()
+  {
+    var h = Build();
+    var (habitId, hvId) = SeedScheduled(h);
+    var date = new DateOnly(2026, 1, 1);
+    h.Vac.WithActive(UserId, new DateOnly(2025, 12, 30), new DateOnly(2026, 1, 5));
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId };
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(1); // 1 vacation row inserted, 0 failed
+
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Vacation)
+      .Should().ContainSingle();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
+  // SAD: frozen habit is NOT failed; freeze consumed and Freeze execution inserted.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task Frozen_IsNotFailed_ConsumesFreeze_AndInsertsFreezeExecution()
+  {
+    var h = Build(freezeBalance: 1);
+    var (habitId, hvId) = SeedScheduled(h);
+    var date = new DateOnly(2026, 1, 1);
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId };
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(1); // 1 freeze row inserted, 0 failed
+
+    h.Prot.TryConsumeFreezeCalls.Should().ContainSingle();
+    h.Prot.FreezeBalance.Should().Be(0); // decremented
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze)
+      .Should().ContainSingle();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  // No freeze available -> the miss falls through to Fail (freeze does not rescue).
+  [Fact]
+  public async Task NoFreezeAvailable_Miss_FallsThroughToFail()
+  {
+    var h = Build(freezeBalance: 0);
+    var (habitId, hvId) = SeedScheduled(h);
+    var date = new DateOnly(2026, 1, 1);
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId };
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(1);
+    h.Prot.TryConsumeFreezeCalls.Should().ContainSingle(); // probed
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze)
+      .Should().BeEmpty(); // nothing inserted (consume returned false)
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+  }
+
+  // ---------------------------------------------------------------------------
+  // A user whose scheduled habits are already protected by a Vacation execution
+  // must NOT have a freeze credit consumed. The freeze branch is skipped entirely
+  // for users on vacation that date (Service.cs step 4): the vacation already
+  // protects the day, so probing/consuming a freeze would only no-op on the
+  // anti-join while burning a credit.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task VacationedUser_DoesNotConsumeFreeze()
+  {
+    var h = Build(freezeBalance: 1);
+    var (habitId, hvId) = SeedScheduled(h);
+    var date = new DateOnly(2026, 1, 1);
+    h.Vac.WithActive(UserId, new DateOnly(2025, 12, 30), new DateOnly(2026, 1, 5));
+
+    await h.Svc.MarkDailyFailures([habitId], date);
+
+    // Correct behavior: the vacation already protects the day; freeze must be left intact.
+    h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
+    h.Prot.FreezeBalance.Should().Be(1);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotent re-run: re-running over the same penaltyRepo / executionId does
+  // not double-enqueue.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task IdempotentRerun_DoesNotDoubleEnqueuePenalty()
+  {
+    var h = Build();
+    var (habitId, hvId) = SeedScheduled(h);
+    var execId = Guid.NewGuid();
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = UserId, ExecutionId = execId };
+    var date = new DateOnly(2026, 1, 1);
+
+    var r1 = await h.Svc.MarkDailyFailures([habitId], date);
+    ((int)r1).Should().Be(1);
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+
+    // Second run: the slot is now occupied (ExistingExecutions), so CreateFailedExecutions
+    // returns nothing; even if a row re-surfaced, EnqueuePending is idempotent on ExecutionId.
+    var r2 = await h.Svc.MarkDailyFailures([habitId], date);
+    ((int)r2).Should().Be(0);
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords[0].HabitExecutionId.Should().Be(execId);
+  }
+
+  // Two failed rows sharing one ExecutionId -> enqueued exactly once.
+  [Fact]
+  public async Task TwoFailedRowsSameExecutionId_EnqueuedExactlyOnce()
+  {
+    var h = Build();
+    var (habitIdA, hvA) = SeedScheduled(h);
+    var (habitIdB, hvB) = SeedScheduled(h);
+    var execId = Guid.NewGuid();
+    h.Repo.FailedRowSeeds[hvA] = new FailedRowSeed { UserId = UserId, ExecutionId = execId };
+    h.Repo.FailedRowSeeds[hvB] = new FailedRowSeed { UserId = UserId, ExecutionId = execId };
+    var date = new DateOnly(2026, 1, 1);
+
+    var res = await h.Svc.MarkDailyFailures([habitIdA, habitIdB], date);
+
+    ((int)res).Should().Be(2); // two failed rows counted
+    h.Penalty.EnqueuedRecords.Should().ContainSingle(); // but only one penalty
+  }
+
+  // ---------------------------------------------------------------------------
+  // ratio=0 / stake=0 -> failed row recorded, but NO penalty enqueued.
+  // Parameterized so the skip-on-zero rule stays valid if amounts change.
+  // ---------------------------------------------------------------------------
+  [Theory]
+  [InlineData(1000, 0)]     // ratio = 0
+  [InlineData(0, 5000)]     // stake = 0
+  [InlineData(0, 0)]        // both 0
+  public async Task ZeroPenalty_FailsButDoesNotEnqueue(int stakeCents, int ratioBasisPoints)
+  {
+    var h = Build();
+    var (habitId, hvId) = SeedScheduled(h);
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed
+    {
+      UserId = UserId,
+      StakeCents = stakeCents,
+      RatioBasisPoints = ratioBasisPoints
+    };
+    var date = new DateOnly(2026, 1, 1);
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(1); // the failed row still counts
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty(); // but no penalty
+  }
+
+  // Positive control for the theory: a non-zero stake/ratio DOES enqueue, with the
+  // expected amount. Parameterized so amount math is locked across tier changes.
+  [Theory]
+  [InlineData(1000, 5000, 5.00)]   // $10 stake @ 50% -> $5.00
+  [InlineData(2000, 2500, 5.00)]   // $20 stake @ 25% -> $5.00
+  [InlineData(500, 10000, 5.00)]   // $5 stake @ 100% -> $5.00
+  [InlineData(1234, 5000, 6.17)]   // 1234c * 5000 / 10000 = 617c -> $6.17
+  public async Task NonZeroPenalty_EnqueuesExpectedAmount(int stakeCents, int ratioBasisPoints, decimal expectedDollars)
+  {
+    var h = Build();
+    var (habitId, hvId) = SeedScheduled(h);
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed
+    {
+      UserId = UserId,
+      StakeCents = stakeCents,
+      RatioBasisPoints = ratioBasisPoints
+    };
+    var date = new DateOnly(2026, 1, 1);
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    ((int)res).Should().Be(1);
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords[0].Amount.Should()
+      .Be(new Money(expectedDollars, Currency.FromCode("USD")));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ordering: vacation insert -> freeze insert -> fail step (by call sequence).
+  // The phases run globally (all vacations, then all freezes, then the single
+  // fail step), so two distinct users exercise the ordering without the freeze
+  // branch having to fire for a vacationing user (which it must not): userVac is
+  // on vacation (vacation insert), userFrz has a freeze credit + a miss (freeze
+  // insert). Comparing call sequence numbers proves the phase ordering.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task Ordering_VacationBeforeFreezeBeforeFail()
+  {
+    const string userVac = "user-vac";
+    const string userFrz = "user-frz";
+
+    var h = Build(freezeBalance: 1);
+    var (vacHabitId, _) = SeedScheduled(h, userVac);
+    var (frzHabitId, frzHvId) = SeedScheduled(h, userFrz);
+    h.Vac.WithActive(userVac, new DateOnly(2025, 12, 30), new DateOnly(2026, 1, 5));
+    h.Repo.FailedRowSeeds[frzHvId] = new FailedRowSeed { UserId = userFrz };
+    var date = new DateOnly(2026, 1, 1);
+
+    var res = await h.Svc.MarkDailyFailures([vacHabitId, frzHabitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+    // 1 vacation row + 1 freeze row + 0 failed (both slots occupied before fail).
+    ((int)res).Should().Be(2);
+
+    var vacSeq = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Single(c => c.Status == ExecutionStatus.Vacation).Seq;
+    var frzSeq = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Single(c => c.Status == ExecutionStatus.Freeze).Seq;
+    var failSeq = h.Repo.CreateFailedExecutionsCalls.Single().Seq;
+
+    vacSeq.Should().BeLessThan(frzSeq);
+    frzSeq.Should().BeLessThan(failSeq);
+
+    // The vacationing user did NOT consume a freeze; only userFrz did.
+    h.Prot.TryConsumeFreezeCalls.Should().ContainSingle();
+    h.Prot.TryConsumeFreezeCalls[0].UserId.Should().Be(userFrz);
+
+    // Both days were protected, so no penalty is enqueued.
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+}

--- a/UnitTest/Protection/SkipLimitTests.cs
+++ b/UnitTest/Protection/SkipLimitTests.cs
@@ -1,0 +1,218 @@
+using App.Error;
+using App.Modules.Entitlement;
+using App.StartUp.Registry;
+using CSharp_Result;
+using Domain.Habit;
+using Domain.Protection;
+using Domain.Subscription;
+using Domain.Vacation;
+using Microsoft.Extensions.Logging.Abstractions;
+using UnitTest.Penalty;
+
+namespace UnitTest.Protection;
+
+// Tests for SKIP CRUD (the HabitService.SkipHabit happy path) and for the
+// MONTHLY SKIP LIMIT enforcement.
+//
+// IMPORTANT architectural note discovered while writing these tests:
+//   * Domain.Habit.HabitService.SkipHabit does NOT enforce any monthly skip
+//     limit. It simply resolves the user-local date and delegates to
+//     repo.SkipHabit. So a "skip beyond the limit" CANNOT be rejected at the
+//     domain-service layer — the cap is enforced one layer up.
+//   * The actual cap lives in App.Modules.Entitlement.EntitlementService
+//     .EnsureSkipsAllowed, which the HabitController calls BEFORE SkipHabit:
+//         GetUserMonthWindow -> EnsureSkipsAllowed -> SkipHabit
+//     EnsureSkipsAllowed compares CountUserSkipsForMonth(used) against the
+//     tier limit (EntitlementKeys.SkipsMonthly) and fails with a
+//     TierInsufficient problem when used >= limit.
+//
+// Therefore the HAPPY path (skip succeeds) and SAD path (skip beyond limit
+// rejected) are unit-tested at the layer that actually owns each behaviour:
+//   - SkipHabit happy path        -> HabitService (delegation + correct date)
+//   - skip-within-limit allowed   -> EntitlementService.EnsureSkipsAllowed
+//   - skip-beyond-limit rejected  -> EntitlementService.EnsureSkipsAllowed
+//
+// The end-to-end controller wiring (Guard -> month window -> EnsureSkipsAllowed
+// -> SkipHabit short-circuiting before the repo write) is integration-only; see
+// needsIntegration in the report.
+public class SkipLimitTests
+{
+  private const string UserId = "user-1";
+
+  private static HabitService BuildHabitService(FakeHabitRepository repo)
+  {
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance: 0);
+    var ent = new FakeEntitlementService();
+    var penaltyRepo = new FakePenaltyRepository();
+    return new HabitService(repo, vac, prot, ent, penaltyRepo, NullLogger<HabitService>.Instance);
+  }
+
+  // ---------------------------------------------------------------------------
+  // SKIP CRUD — happy path on the domain service.
+  // SkipHabit must resolve the user-local current date and delegate to the repo
+  // with exactly the userId/version/date/notes it was given.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public async Task SkipHabit_HappyPath_DelegatesToRepoWithUserLocalDate()
+  {
+    var hvId = Guid.NewGuid();
+    var today = new DateOnly(2026, 6, 7);
+    var repo = new FakeHabitRepository { CurrentDate = today };
+    var svc = BuildHabitService(repo);
+
+    var res = await svc.SkipHabit(UserId, hvId, "felt sick");
+
+    res.IsSuccess().Should().BeTrue();
+    var exec = res.SuccessOrDefault()!;
+    exec.HabitVersionId.Should().Be(hvId);
+    exec.Record.Status.Should().Be(ExecutionStatus.Skipped);
+    exec.Record.Date.Should().Be(today);
+    exec.Record.Notes.Should().Be("felt sick");
+
+    repo.SkipHabitCalls.Should().ContainSingle();
+    repo.SkipHabitCalls[0].Should().Be((UserId, hvId, today, "felt sick"));
+  }
+
+  [Fact]
+  public async Task SkipHabit_PassesNullNotesThrough()
+  {
+    var hvId = Guid.NewGuid();
+    var repo = new FakeHabitRepository { CurrentDate = new DateOnly(2026, 6, 7) };
+    var svc = BuildHabitService(repo);
+
+    var res = await svc.SkipHabit(UserId, hvId, null);
+
+    res.IsSuccess().Should().BeTrue();
+    repo.SkipHabitCalls.Should().ContainSingle();
+    repo.SkipHabitCalls[0].Notes.Should().BeNull();
+  }
+
+  // ---------------------------------------------------------------------------
+  // MONTHLY SKIP LIMIT — happy path: under the cap, EnsureSkipsAllowed succeeds.
+  // Parameterised over (limit, used) so the assertions stay valid as per-tier
+  // limits change.
+  // ---------------------------------------------------------------------------
+  [Theory]
+  [InlineData(5, 0)]   // none used yet
+  [InlineData(5, 4)]   // last allowed skip (used < limit)
+  [InlineData(1, 0)]   // tier with a single monthly skip, none used
+  [InlineData(30, 29)] // higher tier, last allowed skip
+  public async Task EnsureSkipsAllowed_UnderLimit_Succeeds(int limit, int used)
+  {
+    var (start, end) = MonthWindow();
+    var sub = new FakeSubscriptionService("free", limit);
+    var habitRepo = new FakeSkipCountRepository(used);
+    var svc = BuildEntitlement(sub, habitRepo);
+
+    var res = await svc.EnsureSkipsAllowed(UserId, start, end);
+
+    res.IsSuccess().Should().BeTrue();
+    habitRepo.CountUserSkipsForMonthCalls.Should().ContainSingle();
+    habitRepo.CountUserSkipsForMonthCalls[0].Should().Be((UserId, start, end));
+    sub.GetLimitForTierCalls.Should().Contain((("free"), EntitlementKeys.SkipsMonthly));
+  }
+
+  // ---------------------------------------------------------------------------
+  // MONTHLY SKIP LIMIT — sad path: at/over the cap, EnsureSkipsAllowed must
+  // REJECT (used >= limit). This asserts the CORRECT behaviour: a user must NOT
+  // be able to skip beyond the monthly limit.
+  // ---------------------------------------------------------------------------
+  [Theory]
+  [InlineData(5, 5)]    // exactly at the cap
+  [InlineData(5, 6)]    // over the cap (defensive)
+  [InlineData(1, 1)]    // single-skip tier, already used
+  [InlineData(0, 0)]    // tier with zero skips: never allowed
+  [InlineData(30, 30)]  // higher tier at cap
+  public async Task EnsureSkipsAllowed_AtOrOverLimit_IsRejected(int limit, int used)
+  {
+    var (start, end) = MonthWindow();
+    var sub = new FakeSubscriptionService("free", limit);
+    var habitRepo = new FakeSkipCountRepository(used);
+    var svc = BuildEntitlement(sub, habitRepo);
+
+    var res = await svc.EnsureSkipsAllowed(UserId, start, end);
+
+    res.IsFailure().Should().BeTrue();
+    var err = res.FailureOrDefault();
+    err.Should().BeOfType<DomainProblemException>();
+    var problem = ((DomainProblemException)err!).Problem;
+    problem.Should().BeOfType<App.Error.V1.TierInsufficient>();
+    var tier = (App.Error.V1.TierInsufficient)problem;
+    tier.LimitKey.Should().Be(EntitlementKeys.SkipsMonthly);
+    tier.LimitValue.Should().Be(limit);
+    tier.Tier.Should().Be("free");
+  }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+  private static EntitlementService BuildEntitlement(
+    FakeSubscriptionService sub, FakeSkipCountRepository habitRepo)
+    => new(sub, new FakeVacationRepository(), habitRepo, new NoopFreezePolicy());
+
+  private static (DateOnly Start, DateOnly End) MonthWindow()
+    => (new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+}
+
+// ---------------------------------------------------------------------------
+// Local minimal fakes for the EntitlementService dependencies that the SHARED
+// Fakes.cs does not back (the shared FakeHabitRepository throws on
+// CountUserSkipsForMonth, and there is no subscription / freeze-policy fake).
+// Kept here, namespace-local, so the shared file stays untouched.
+// ---------------------------------------------------------------------------
+
+internal sealed class FakeSubscriptionService(string tier, int skipsMonthlyLimit) : ISubscriptionService
+{
+  public List<(string Tier, string Key)> GetLimitForTierCalls { get; } = [];
+
+  public Task<Result<string>> GetUserTier(string userId)
+    => Task.FromResult<Result<string>>(tier);
+
+  public Task<Result<int>> GetLimitForTier(string t, string key)
+  {
+    GetLimitForTierCalls.Add((t, key));
+    var limit = key == EntitlementKeys.SkipsMonthly ? skipsMonthlyLimit : 0;
+    return Task.FromResult<Result<int>>(limit);
+  }
+}
+
+internal sealed class NoopFreezePolicy : IFreezePolicy
+{
+  public int ComputeFreezeMax(int baseCap, int userMaxStreak) => baseCap;
+}
+
+// Minimal IHabitRepository that only backs the skip-count query
+// EnsureSkipsAllowed uses; everything else throws so misuse is loud.
+internal sealed class FakeSkipCountRepository(int usedSkips) : IHabitRepository
+{
+  public List<(string UserId, DateOnly Start, DateOnly End)> CountUserSkipsForMonthCalls { get; } = [];
+
+  public Task<Result<int>> CountUserSkipsForMonth(string userId, DateOnly monthStart, DateOnly monthEnd)
+  {
+    CountUserSkipsForMonthCalls.Add((userId, monthStart, monthEnd));
+    return Task.FromResult<Result<int>>(usedSkips);
+  }
+
+  // ---- unused members ----
+  public Task<Result<List<HabitVersionPrincipal>>> GetActiveHabitVersions(string userId, DateOnly date) => throw new NotImplementedException();
+  public Task<Result<List<HabitVersionPrincipal>>> SearchHabits(HabitSearch habitSearch) => throw new NotImplementedException();
+  public Task<Result<HabitPrincipal?>> GetHabit(Guid habitId) => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal?>> GetCurrentVersion(string userId, Guid habitId) => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal>> Create(string userId, HabitVersionRecord versionRecord) => throw new NotImplementedException();
+  public Task<Result<HabitVersionPrincipal?>> Update(Guid habitId, string userId, HabitVersionRecord versionRecord, bool enabled) => throw new NotImplementedException();
+  public Task<Result<Unit?>> Delete(Guid habitId, string userId) => throw new NotImplementedException();
+  public Task<Result<List<FailedExecutionRow>>> CreateFailedExecutions(List<Guid> habitIds, DateOnly date) => throw new NotImplementedException();
+  public Task<Result<int>> CreateExecutionsForVersionsWithStatus(List<Guid> habitVersionIds, DateOnly date, ExecutionStatus status) => throw new NotImplementedException();
+  public Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId) => throw new NotImplementedException();
+  public Task<Result<HabitExecutionPrincipal>> CompleteHabit(string userId, Guid habitVersionId, DateOnly date, string? notes) => throw new NotImplementedException();
+  public Task<Result<HabitExecutionPrincipal>> SkipHabit(string userId, Guid habitVersionId, DateOnly date, string? notes) => throw new NotImplementedException();
+  public Task<Result<List<HabitExecutionPrincipal>>> SearchHabitExecutions(string userId, HabitExecutionSearch habitExecutionSearch) => throw new NotImplementedException();
+  public Task<Result<List<HabitVersionPrincipal>>> GetVersions(string userId, Guid habitId) => throw new NotImplementedException();
+  public Task<Result<int>> CountHabitsForUser(string userId) => throw new NotImplementedException();
+  public Task<Result<List<HabitVersionPrincipal>>> GetActiveHabitVersionsByIds(List<Guid> habitIds, DateOnly date) => throw new NotImplementedException();
+  public Task<Result<List<HabitPrincipal>>> GetHabitsByIds(List<Guid> habitIds) => throw new NotImplementedException();
+  public Task<Result<bool>> HasAnyCompletedOrSkippedForVersions(List<Guid> habitVersionIds, DateOnly date) => throw new NotImplementedException();
+  public Task<Result<List<string>>> GetDistinctTimezonesForEnabledHabits() => throw new NotImplementedException();
+  public Task<Result<List<Guid>>> GetEnabledHabitIdsByTimezone(string timezone) => throw new NotImplementedException();
+}

--- a/UnitTest/Protection/VacationPauseTests.cs
+++ b/UnitTest/Protection/VacationPauseTests.cs
@@ -1,0 +1,285 @@
+using CSharp_Result;
+using Domain.Habit;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaMoney;
+using UnitTest.Penalty;
+
+namespace UnitTest.Protection;
+
+// Unit tests for the VACATION-pause branch of HabitService.MarkDailyFailures.
+//
+// Contract under test (Service.cs steps 3 + 5):
+//   For a habit scheduled today whose owner has >=1 active vacation window on
+//   that date, the service pre-inserts a Vacation execution
+//   (CreateExecutionsForVersionsWithStatus(..., Vacation)) BEFORE the fail step.
+//   The pre-insert occupies the (hvId, date) slot, so the CreateFailedExecutions
+//   anti-join skips it: the habit is NOT Failed and no penalty is enqueued.
+//
+// NOTE on date/timezone/boundary resolution: HabitService only reads
+// vacations.Count for the queried date. WHICH windows are "active on date" — the
+// start/end inclusivity, multi-day spans, timezone-shifted day boundaries and
+// window overlap — is entirely decided by IVacationRepository.ListActiveForUserOnDate
+// (a SQL query). None of that logic lives in HabitService, so it cannot be
+// exercised with a fake that just returns a seeded .Count. Those edge cases are
+// reported in needsIntegration rather than faked into green here.
+public class VacationPauseTests
+{
+  private const string UserId = "user-vac-1";
+
+  private sealed record Harness(
+    FakeHabitRepository Repo,
+    FakeVacationRepository Vac,
+    FakeProtectionRepository Prot,
+    FakeEntitlementService Ent,
+    FakePenaltyRepository Penalty,
+    HabitService Svc);
+
+  // freezeBalance defaults to 0 so the freeze branch never fires unless a test
+  // opts in: vacation behaviour must be isolated from the freeze branch.
+  private static Harness Build(int freezeBalance = 0)
+  {
+    var log = new CallLog();
+    var repo = new FakeHabitRepository(log);
+    var vac = new FakeVacationRepository();
+    var prot = new FakeProtectionRepository(freezeBalance);
+    var ent = new FakeEntitlementService();
+    var penalty = new FakePenaltyRepository();
+    var svc = new HabitService(repo, vac, prot, ent, penalty, NullLogger<HabitService>.Instance);
+    return new Harness(repo, vac, prot, ent, penalty, svc);
+  }
+
+  // Seed one scheduled habit + version that would FAIL absent any protection.
+  private static (Guid HabitId, Guid HvId, Guid ExecutionId) SeedScheduledMiss(
+    Harness h, string userId = UserId)
+  {
+    var habitId = Guid.NewGuid();
+    var hvId = Guid.NewGuid();
+    var execId = Guid.NewGuid();
+    h.Repo.Habits.Add(HabitFakeFactory.Habit(habitId, userId));
+    h.Repo.ActiveVersions.Add(HabitFakeFactory.Version(hvId, habitId));
+    h.Repo.FailedRowSeeds[hvId] = new FailedRowSeed { UserId = userId, ExecutionId = execId };
+    return (habitId, hvId, execId);
+  }
+
+  // -------------------------------------------------------------------------
+  // HAPPY PATH: active vacation pauses the habit.
+  // -------------------------------------------------------------------------
+
+  [Fact]
+  public async Task ActiveVacation_SchedulesVacationExecution_AndDoesNotFail()
+  {
+    var h = Build();
+    var (habitId, hvId, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+
+    // A Vacation execution was inserted for the scheduled version.
+    var vacationInserts = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Vacation).ToList();
+    vacationInserts.Should().ContainSingle();
+    vacationInserts[0].HvIds.Should().Contain(hvId);
+    vacationInserts[0].Date.Should().Be(date);
+
+    // It was NOT failed: the fail step found nothing to fail (slot occupied).
+    h.Repo.CreateFailedExecutionsCalls.Should().ContainSingle();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+
+    // No penalty enqueued because nothing failed.
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+
+    // Return value counts the protected (vacation) row, not a failure.
+    ((int)res).Should().Be(1);
+  }
+
+  [Fact]
+  public async Task ActiveVacation_DoesNotConsumeFreeze()
+  {
+    // Vacation runs BEFORE the freeze branch and the freeze branch is SKIPPED for
+    // a user on vacation that date: the vacation insert already protects every
+    // scheduled habit, so consuming a freeze would only no-op on the anti-join
+    // while burning a credit. Even with freeze available, none must be consumed.
+    var h = Build(freezeBalance: 5);
+    var (habitId, hvId, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 10), new DateOnly(2026, 6, 10));
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+
+    // Vacation insert happened.
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Count(c => c.Status == ExecutionStatus.Vacation).Should().Be(1);
+
+    // The freeze branch was skipped: no freeze probed, none consumed, no insert.
+    h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
+    h.Prot.FreezeBalance.Should().Be(5); // untouched
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Freeze).Should().BeEmpty();
+
+    // Not failed, no penalty.
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task ActiveVacation_OrdersVacationInsertBeforeFailStep()
+  {
+    var h = Build();
+    var (habitId, _, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    await h.Svc.MarkDailyFailures([habitId], date);
+
+    var vacationSeq = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Single(c => c.Status == ExecutionStatus.Vacation).Seq;
+    var failSeq = h.Repo.CreateFailedExecutionsCalls.Single().Seq;
+
+    vacationSeq.Should().BeLessThan(failSeq,
+      "the Vacation pre-insert must occupy the slot before the fail anti-join runs");
+  }
+
+  [Theory]
+  [InlineData(1)]
+  [InlineData(2)]
+  [InlineData(3)]
+  public async Task MultipleVacationWindows_SamePauseOutcome(int windowCount)
+  {
+    // The service only reads vacations.Count > 0, so 1..N overlapping windows
+    // all yield the identical pause. Parameterized so it stays valid if window
+    // limits / overlap rules change at the repository layer.
+    var h = Build();
+    var (habitId, _, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    for (var i = 0; i < windowCount; i++)
+      h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Count(c => c.Status == ExecutionStatus.Vacation).Should().Be(1);
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task VacationPausesAllScheduledHabitsForUser_OnSameDay()
+  {
+    var h = Build();
+    var a = SeedScheduledMiss(h);
+    var b = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    var res = await h.Svc.MarkDailyFailures([a.HabitId, b.HabitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+
+    var vacationInsert = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Single(c => c.Status == ExecutionStatus.Vacation);
+    vacationInsert.HvIds.Should().BeEquivalentTo([a.HvId, b.HvId]);
+
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+    ((int)res).Should().Be(2); // two vacation rows inserted
+  }
+
+  // -------------------------------------------------------------------------
+  // SAD PATH: no active vacation -> habit fails normally.
+  // -------------------------------------------------------------------------
+
+  [Fact]
+  public async Task NoActiveVacation_HabitFails_AndPenaltyEnqueued()
+  {
+    var h = Build();
+    var (habitId, _, execId) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    // No vacation seeded for UserId.
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+
+    // No vacation inserts at all.
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Vacation).Should().BeEmpty();
+
+    // The habit was failed.
+    h.Repo.CreateFailedExecutionsCalls.Should().ContainSingle();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+
+    // Penalty enqueued for the failed execution.
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords[0].HabitExecutionId.Should().Be(execId);
+    h.Penalty.EnqueuedRecords[0].Status.Should().Be(Domain.Penalty.PenaltyStatus.Pending);
+    h.Penalty.EnqueuedRecords[0].Amount.Should()
+      .Be(new Money(5.00m, Currency.FromCode("USD"))); // 1000c * 5000bps / 10000
+    ((int)res).Should().Be(1); // one failure
+  }
+
+  [Fact]
+  public async Task VacationForDifferentUser_DoesNotPauseThisUsersHabit()
+  {
+    var h = Build();
+    var (habitId, _, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    // Vacation belongs to an unrelated user; ListActiveForUserOnDate is keyed by
+    // userId, so this user's habit must still fail.
+    h.Vac.WithActive("some-other-user", new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+    h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Vacation).Should().BeEmpty();
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().ContainSingle();
+    h.Penalty.EnqueuedRecords.Should().ContainSingle();
+  }
+
+  [Fact]
+  public async Task VacationQueriedForExactMarkDate()
+  {
+    // The vacation lookup must use the SAME date being marked (no off-by-one).
+    var h = Build();
+    var (habitId, _, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+
+    await h.Svc.MarkDailyFailures([habitId], date);
+
+    h.Vac.ListActiveForUserOnDateCalls.Should().ContainSingle();
+    h.Vac.ListActiveForUserOnDateCalls[0].UserId.Should().Be(UserId);
+    h.Vac.ListActiveForUserOnDateCalls[0].Date.Should().Be(date);
+  }
+
+  [Fact]
+  public async Task VacationInsertIsIdempotent_WhenSlotAlreadyExists()
+  {
+    // Model a pre-existing execution row for (hvId, date) — e.g. a Vacation row
+    // already written by an earlier pass within the after-midnight window. The
+    // re-run must not double-fail and must not enqueue a penalty.
+    var h = Build();
+    var (habitId, hvId, _) = SeedScheduledMiss(h);
+    var date = new DateOnly(2026, 6, 10);
+    h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
+    h.Repo.ExistingExecutions.Add((hvId, date)); // slot already taken
+
+    var res = await h.Svc.MarkDailyFailures([habitId], date);
+
+    res.IsSuccess().Should().BeTrue();
+    // Vacation insert is a no-op (0 new rows) because the slot exists.
+    var vacInserts = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+      .Where(c => c.Status == ExecutionStatus.Vacation).ToList();
+    vacInserts.Should().ContainSingle();
+    // Nothing failed, nothing enqueued.
+    h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
+    h.Penalty.EnqueuedRecords.Should().BeEmpty();
+    ((int)res).Should().Be(0); // 0 inserted (no-op) + 0 frozen + 0 failed
+  }
+}

--- a/UnitTest/Protection/VacationPauseTests.cs
+++ b/UnitTest/Protection/VacationPauseTests.cs
@@ -172,18 +172,18 @@ public class VacationPauseTests
   public async Task VacationPausesAllScheduledHabitsForUser_OnSameDay()
   {
     var h = Build();
-    var a = SeedScheduledMiss(h);
+    var (HabitId, HvId, ExecutionId) = SeedScheduledMiss(h);
     var b = SeedScheduledMiss(h);
     var date = new DateOnly(2026, 6, 10);
     h.Vac.WithActive(UserId, new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30));
 
-    var res = await h.Svc.MarkDailyFailures([a.HabitId, b.HabitId], date);
+    var res = await h.Svc.MarkDailyFailures([HabitId, b.HabitId], date);
 
     res.IsSuccess().Should().BeTrue();
 
-    var vacationInsert = h.Repo.CreateExecutionsForVersionsWithStatusCalls
+    var (Seq, HvIds, Date, Status) = h.Repo.CreateExecutionsForVersionsWithStatusCalls
       .Single(c => c.Status == ExecutionStatus.Vacation);
-    vacationInsert.HvIds.Should().BeEquivalentTo([a.HvId, b.HvId]);
+    HvIds.Should().BeEquivalentTo([HvId, b.HvId]);
 
     h.Repo.CreateFailedExecutionsCalls[0].Returned.Should().BeEmpty();
     h.Penalty.EnqueuedRecords.Should().BeEmpty();

--- a/UnitTest/Protection/VacationPauseTests.cs
+++ b/UnitTest/Protection/VacationPauseTests.cs
@@ -117,7 +117,7 @@ public class VacationPauseTests
 
     // The freeze branch was skipped: no freeze probed, none consumed, no insert.
     h.Prot.TryConsumeFreezeCalls.Should().BeEmpty();
-    h.Prot.FreezeBalance.Should().Be(5); // untouched
+    h.Prot.BalanceFor(UserId).Should().Be(5); // untouched
     h.Repo.CreateExecutionsForVersionsWithStatusCalls
       .Where(c => c.Status == ExecutionStatus.Freeze).Should().BeEmpty();
 


### PR DESCRIPTION
## Problem

`MarkDailyFailures` (the nightly cron that marks habit misses and enqueues penalties) ran the **freeze** phase even when a user was on **vacation** that day.

Vacation pre-inserts a protection row for every scheduled habit. The freeze phase's "did anything happen today?" guard (`HasAnyCompletedOrSkippedForVersions`) only counts `Completed`/`Skipped` rows — **not** `Vacation` — so for a vacationing user it saw "nothing done", called `TryConsumeFreeze` (decrementing the user's freeze credit), then the follow-up `Freeze` insert no-op'd on the anti-join because the `Vacation` row already occupied the slot.

**Net effect:** a freeze credit was silently burned on a day that vacation already protected. Not money-losing (no wrong charge), but users lose an earned/paid freeze for nothing.

## Fix

`Domain/Habit/Service.cs` → `MarkDailyFailures`:
- The vacation phase now records each user with an active vacation window in a `usersOnVacation` set.
- The freeze phase `continue`s for those users — vacation already protects the whole day, so there's nothing for freeze to do.

## Interaction recap (skip / freeze / vacation × penalty)

Each habit-day ends with exactly one execution status; first writer wins via the `LEFT JOIN ... he.Id IS NULL` anti-join. Order: **Vacation → Freeze → Fail → enqueue penalty**. Only `Failed` rows create a `Pending` penalty (later drained + charged to the charity). `Skipped`/`Freeze`/`Vacation` all land before the fail step, so each blocks the penalty.

## Tests (`UnitTest/Protection`)

- `VacationedUser_DoesNotConsumeFreeze` — was a red spec for this exact bug, now green.
- `Ordering_VacationBeforeFreezeBeforeFail` — rewritten to use two users (one vacation, one freeze) since freeze no longer fires for a vacationing user.
- `ActiveVacation_DoesNotConsumeFreeze` — strengthened to assert freeze is never probed/consumed.
- Full unit suite green (84 passed, 1 pre-existing skip).

> Note: this PR also brings in the `UnitTest/Protection/` test suite (Fakes + freeze/skip/vacation/daily-failure specs), which was not yet on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vacation protection now prevents freeze-credit consumption for vacationed users for the full marked day.
  * Freeze-credit consume/cap behavior is enforced correctly and remains idempotent per user/date and per habit/week award record.
  * Completed/skipped habits still bypass failure and freeze processing, and penalties aren’t duplicated on reruns.
* **Tests**
  * Added new unit test suites for vacation pause, freeze consume/cap, skip-limit enforcement, and daily failure orchestration, backed by deterministic in-memory fakes and execution call ordering checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->