### PR TITLE
feat: add Logto impersonation script for automated E2E user tokens

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,57 @@
+# E2E test tooling
+
+## `get-user-token.sh` — real user tokens without a browser
+
+Mints a genuine Logto user access token via impersonation
+([docs](https://docs.logto.io/developers/user-impersonation)): M2M creds →
+management token → subject token for the target user → OAuth token exchange.
+zinc cannot tell the result apart from a normal login token.
+
+### Usage
+
+```bash
+TOKEN=$(
+  LOGTO_ENDPOINT=https://api.lithium.alcohol.pichu.cluster.atomi.cloud \
+  LOGTO_M2M_ID=<management m2m app id> \
+  LOGTO_M2M_SECRET=<management m2m secret> \
+  EXCHANGE_APP_ID=<user-facing app id, e.g. the alcohol.neon Native app> \
+  API_RESOURCE=https://api.zinc.alcohol.pichu \
+  USER_EMAIL=testuser@lazytax.club \
+  scripts/e2e/get-user-token.sh
+)
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.zinc.alcohol.pichu.cluster.atomi.cloud/api/v1/subscription/<userId>
+```
+
+Notes:
+
+- On lithium's current Logto version, the token-exchange grant works for
+  **user-facing** apps (Native/SPA/Traditional) and is rejected for M2M apps.
+  Native apps are public clients — `EXCHANGE_APP_SECRET` is not needed.
+- The script prints ONLY the token on stdout; all diagnostics go to stderr.
+
+### Security handling rules
+
+The script contains no credentials, but it consumes one powerful secret and
+emits one live token. Handle both accordingly:
+
+1. **`LOGTO_M2M_SECRET` is the Management API key** — whoever holds it can
+   administer all users. In CI, store it as a GitHub Actions **secret**
+   (auto-masked); locally, pull it from Infisical into the environment, never
+   into files or shell history.
+2. **Never log the output token.** Capture it into a variable; in GitHub
+   Actions, `echo "::add-mask::$TOKEN"` immediately after capture. Never run
+   the script under `set -x`.
+3. **Blast radius**: the token is short-lived and belongs to a dedicated test
+   user — keep it that way. Do not impersonate real users in tests.
+4. **pichu-only policy.** Do not wire raichu (production) management secrets
+   into any automated job. Production impersonation must remain a deliberate,
+   manual, audited act.
+
+### Test identities (pichu)
+
+| What | Value |
+| ------------------ | ----------------------------------------- |
+| Test user | `testuser@lazytax.club` (`tajahe2jbu4f`) |
+| Exchange app | alcohol.neon Native (public) |
+| Management M2M app | zinc's `Auth.Management` (Id from config, secret in Infisical `ATOMI_AUTH__MANAGEMENT__SECRET`) |

--- a/scripts/e2e/get-user-token.sh
+++ b/scripts/e2e/get-user-token.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Mint a REAL user access token via Logto impersonation (token exchange),
+# without any browser or password — for automated E2E tests against a live
+# landscape. https://docs.logto.io/developers/user-impersonation
+#
+#   M2M creds ──▶ management token ──▶ POST /api/subject-tokens {userId}
+#             ──▶ POST /oidc/token (grant_type=token-exchange) ──▶ user JWT
+#
+# The resulting token is indistinguishable from a normal login token: same
+# issuer, audience and claims — zinc's auth accepts it as the user.
+#
+# Required env:
+#   LOGTO_ENDPOINT        e.g. https://api.lithium.alcohol.pichu.cluster.atomi.cloud
+#   LOGTO_M2M_ID          management M2M app id   (zinc's Auth.Management.Id works)
+#   LOGTO_M2M_SECRET      management M2M app secret
+#   EXCHANGE_APP_ID       app used for the exchange. On lithium's current Logto
+#                         version, USER-FACING apps (Native/SPA/Traditional)
+#                         accept the token-exchange grant out of the box, while
+#                         M2M apps reject it — use e.g. the alcohol.neon Native
+#                         app id. Verified on pichu 2026-07-04.
+#   EXCHANGE_APP_SECRET   its secret (omit for public apps like Native)
+#   API_RESOURCE          audience, e.g. https://api.zinc.alcohol.pichu
+#   USER_ID               Logto user id to impersonate (or set USER_EMAIL)
+# Optional:
+#   USER_EMAIL            resolved to USER_ID via the Management API
+#   MGMT_RESOURCE         default https://default.logto.app/api (self-hosted)
+#   SCOPES                extra scopes for the user token (space-separated)
+#
+# Output: the user access token on stdout (nothing else), so callers can do
+#   TOKEN=$(scripts/e2e/get-user-token.sh)
+set -euo pipefail
+
+: "${LOGTO_ENDPOINT:?}" "${LOGTO_M2M_ID:?}" "${LOGTO_M2M_SECRET:?}"
+: "${EXCHANGE_APP_ID:?}" "${API_RESOURCE:?}"
+MGMT_RESOURCE="${MGMT_RESOURCE:-https://default.logto.app/api}"
+
+err() {
+  echo "get-user-token: $*" >&2
+  exit 1
+}
+need() { command -v "$1" >/dev/null || err "missing dependency: $1"; }
+need curl
+need jq
+
+# 1. Management token (client credentials) — the part that IS automatable today.
+mgmt_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/oidc/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "$LOGTO_M2M_ID:$LOGTO_M2M_SECRET" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "resource=$MGMT_RESOURCE" \
+  --data-urlencode "scope=all" | jq -r .access_token) || err "management token request failed"
+if [ -z "$mgmt_token" ] || [ "$mgmt_token" = "null" ]; then err "no management token in response"; fi
+
+# 2. Resolve email -> user id if needed.
+if [ -z "${USER_ID:-}" ]; then
+  : "${USER_EMAIL:?set USER_ID or USER_EMAIL}"
+  USER_ID=$(curl -sf "$LOGTO_ENDPOINT/api/users?search=$(jq -rn --arg e "$USER_EMAIL" '$e|@uri')" \
+    -H "Authorization: Bearer $mgmt_token" |
+    jq -r --arg e "$USER_EMAIL" '.[] | select(.primaryEmail==$e) | .id' | head -1)
+  [ -n "$USER_ID" ] || err "no user found for $USER_EMAIL"
+fi
+
+# 3. Subject token for the target user (Management API; short-lived, single-use).
+subject_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/api/subject-tokens" \
+  -H "Authorization: Bearer $mgmt_token" -H "Content-Type: application/json" \
+  -d "{\"userId\": \"$USER_ID\"}" | jq -r .subjectToken) || err "subject-token request failed (Logto too old, or missing permission)"
+if [ -z "$subject_token" ] || [ "$subject_token" = "null" ]; then err "no subjectToken in response"; fi
+
+# 4. Exchange it for a real user access token scoped to the API resource.
+auth_args=(-u "$EXCHANGE_APP_ID:${EXCHANGE_APP_SECRET:-}")
+[ -z "${EXCHANGE_APP_SECRET:-}" ] && auth_args=(--data-urlencode "client_id=$EXCHANGE_APP_ID")
+user_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/oidc/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  "${auth_args[@]}" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=$subject_token" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  --data-urlencode "resource=$API_RESOURCE" \
+  ${SCOPES:+--data-urlencode "scope=$SCOPES"} |
+  jq -r .access_token) || err "token exchange failed (is the grant enabled on $EXCHANGE_APP_ID?)"
+if [ -z "$user_token" ] || [ "$user_token" = "null" ]; then err "no access_token in exchange response"; fi
+
+echo "$user_token"


### PR DESCRIPTION
Solves the "can't get a real user token automatically" blocker for post-deploy E2E testing.

`scripts/e2e/get-user-token.sh`: M2M creds → Logto management token → subject token for a test user → OAuth token exchange → **real user access token**, no browser/password. Verified end-to-end on pichu: impersonated token for testuser@lazytax.club → `GET /api/v1/subscription/{userId}` → 200 `{"tier":"free"}`.

Notes discovered live:
- lithium's Logto accepts the token-exchange grant for user-facing apps (Native/SPA/Traditional) out of the box; M2M apps reject it — use e.g. the alcohol.neon Native app id (public client, no secret).
- Subject tokens require Management API access, so impersonation stays gated behind the existing M2M credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new end-to-end helper to generate real user access tokens for test runs.
  * Supports resolving a user by email or user ID and handles token exchange with stricter validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->