### PR TITLE
feat: web-handoff magic link + regional subscription CTA

### DIFF
--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -1001,7 +1001,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["Scheme", "Host"]
     },
     "Auth": {
       "title": "AuthOption",

--- a/App/Config/schema.json
+++ b/App/Config/schema.json
@@ -34,6 +34,9 @@
     "ErrorPortal": {
       "$ref": "#/definitions/ErrorPortal"
     },
+    "WebPortal": {
+      "$ref": "#/definitions/WebPortal"
+    },
     "Auth": {
       "$ref": "#/definitions/Auth"
     },
@@ -942,6 +945,61 @@
         "Host": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "WebPortal": {
+      "title": "WebPortalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Scheme": {
+          "type": "string",
+          "enum": ["http", "https"]
+        },
+        "Host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "HandoffPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "RedirectPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "OttExpirySeconds": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 3600
+        },
+        "Cta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ios": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            },
+            "android": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            }
+          }
+        }
+      },
+      "definitions": {
+        "CtaPlatform": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SubscribeAllowed": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$"
+              }
+            }
+          }
         }
       }
     },

--- a/App/Config/settings.example.yaml
+++ b/App/Config/settings.example.yaml
@@ -132,6 +132,17 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+WebPortal:
+  Scheme: https
+  Host: portal.example.com
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed: [US]
+    android:
+      SubscribeAllowed: [US]
 Database:
   Main:
     Host: zinc-maindb

--- a/App/Config/settings.pichu.yaml
+++ b/App/Config/settings.pichu.yaml
@@ -49,6 +49,10 @@ HttpClient:
 Disbursement:
   Enabled: true
 
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pichu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/App/Config/settings.pikachu.yaml
+++ b/App/Config/settings.pikachu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pikachu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/App/Config/settings.raichu.yaml
+++ b/App/Config/settings.raichu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: lazytax.club
+
 Auth:
   Enabled: true
   Settings:

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -41,6 +41,23 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+# Web billing portal handoff (neon app -> browser magic link). Scheme/Host are
+# the argon portal for the landscape; the Cta allowlists are the storefronts
+# where a free user may see the web "subscribe" link-out (US: Epic ruling,
+# EU-27: DMA). Anything not listed (incl. SG) fails closed to the neutral CTA.
+WebPortal:
+  Scheme: http
+  Host: localhost:3000
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
+    android:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
 # Security
 Cors:
   - Name: AllowAll

--- a/App/Error/V1/HandoffNotAvailable.cs
+++ b/App/Error/V1/HandoffNotAvailable.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using NJsonSchema.Annotations;
+
+namespace App.Error.V1;
+
+[Description(
+  "This error means the web billing portal handoff is not offered for the caller's platform and storefront region.")]
+public class HandoffNotAvailable : IDomainProblem
+{
+  public HandoffNotAvailable() { }
+
+  public HandoffNotAvailable(string platform, string? storefront)
+  {
+    this.Platform = platform;
+    this.Storefront = storefront ?? string.Empty;
+  }
+
+  [JsonIgnore, JsonSchemaIgnore] public string Id { get; } = "handoff_not_available";
+  [JsonIgnore, JsonSchemaIgnore] public string Title { get; } = "Handoff Not Available";
+  [JsonIgnore, JsonSchemaIgnore] public string Version { get; } = "v1";
+
+  [JsonIgnore, JsonSchemaIgnore]
+  public string Detail { get; } = "Web subscription handoff is not offered in this region.";
+
+  [Description("The caller's platform")] public string Platform { get; } = string.Empty;
+
+  [Description("The caller's storefront country (ISO 3166-1 alpha-2), empty if unknown")]
+  public string Storefront { get; } = string.Empty;
+}

--- a/App/Modules/Auth/API/V1/AuthController.cs
+++ b/App/Modules/Auth/API/V1/AuthController.cs
@@ -1,0 +1,36 @@
+using System.Net.Mime;
+using App.Modules.Common;
+using App.StartUp.Services.Auth;
+using App.Utility;
+using Asp.Versioning;
+using CSharp_Result;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Modules.Auth.API.V1;
+
+[ApiVersion(1.0)]
+[ApiController]
+[Consumes(MediaTypeNames.Application.Json)]
+[Route("api/v{version:apiVersion}/[controller]")]
+public class AuthController(
+  IWebHandoffService webHandoffService,
+  IAuthHelper authHelper,
+  WebHandoffReqValidator webHandoffValidator
+) : AtomiControllerBase(authHelper)
+{
+  // Mints a Logto one-time token for the CALLER (identity comes exclusively
+  // from the JWT sub — there is no way to request another user's token) and
+  // returns the magic-link URL into the web billing portal.
+  [Authorize, HttpPost("web-handoff")]
+  public async Task<ActionResult<WebHandoffRes>> WebHandoff([FromBody] WebHandoffReq req)
+  {
+    var sub = this.Sub();
+    var result = await this.GuardAsync(sub)
+      .ThenAwait(_ => webHandoffValidator.ValidateAsyncResult(req, "Invalid WebHandoffReq"))
+      .ThenAwait(r => webHandoffService.CreateHandoff(sub!, r.Platform, r.Storefront))
+      .Then(h => new WebHandoffRes(h.Url, h.ExpiresInSeconds), Errors.MapNone);
+
+    return this.ReturnResult(result);
+  }
+}

--- a/App/Modules/Auth/API/V1/AuthController.cs
+++ b/App/Modules/Auth/API/V1/AuthController.cs
@@ -22,6 +22,10 @@ public class AuthController(
   // Mints a Logto one-time token for the CALLER (identity comes exclusively
   // from the JWT sub — there is no way to request another user's token) and
   // returns the magic-link URL into the web billing portal.
+  //
+  // platform/storefront are client-asserted, so the neutral-region 403 is a
+  // best-effort compliance backstop, not a security boundary: the token is
+  // only ever minted for the caller's own account either way.
   [Authorize, HttpPost("web-handoff")]
   public async Task<ActionResult<WebHandoffRes>> WebHandoff([FromBody] WebHandoffReq req)
   {

--- a/App/Modules/Auth/API/V1/AuthModel.cs
+++ b/App/Modules/Auth/API/V1/AuthModel.cs
@@ -1,0 +1,11 @@
+namespace App.Modules.Auth.API.V1;
+
+public record WebHandoffReq(
+  string Platform,
+  string? Storefront
+);
+
+public record WebHandoffRes(
+  string Url,
+  int ExpiresInSeconds
+);

--- a/App/Modules/Auth/API/V1/AuthValidator.cs
+++ b/App/Modules/Auth/API/V1/AuthValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace App.Modules.Auth.API.V1;
+
+public class WebHandoffReqValidator : AbstractValidator<WebHandoffReq>
+{
+  public WebHandoffReqValidator()
+  {
+    RuleFor(x => x.Platform)
+      .NotEmpty()
+      .Must(p => p is "ios" or "android")
+      .WithMessage("Platform must be one of: ios, android");
+
+    // Storefront is optional (the app may fail to read it); the CTA matrix
+    // fails closed to neutral when it is absent.
+    RuleFor(x => x.Storefront)
+      .Matches("^[A-Za-z]{2}$")
+      .When(x => !string.IsNullOrEmpty(x.Storefront))
+      .WithMessage("Storefront must be an ISO 3166-1 alpha-2 country code");
+  }
+}

--- a/App/Modules/Auth/API/V1/AuthValidator.cs
+++ b/App/Modules/Auth/API/V1/AuthValidator.cs
@@ -13,8 +13,9 @@ public class WebHandoffReqValidator : AbstractValidator<WebHandoffReq>
 
     // Storefront is optional (the app may fail to read it); the CTA matrix
     // fails closed to neutral when it is absent.
+    // \z (not $) so a trailing newline can't sneak past the exact-length match.
     RuleFor(x => x.Storefront)
-      .Matches("^[A-Za-z]{2}$")
+      .Matches(@"^[A-Za-z]{2}\z")
       .When(x => !string.IsNullOrEmpty(x.Storefront))
       .WithMessage("Storefront must be an ISO 3166-1 alpha-2 country code");
   }

--- a/App/Modules/Auth/WebHandoffService.cs
+++ b/App/Modules/Auth/WebHandoffService.cs
@@ -1,0 +1,104 @@
+using App.StartUp.Options;
+using App.StartUp.Services.Auth;
+using CSharp_Result;
+using Domain.Exceptions;
+using Domain.Subscription;
+using Domain.User;
+using Microsoft.Extensions.Options;
+
+namespace App.Modules.Auth;
+
+// CTA variants for the subscription screen. Unknown values must be treated as
+// Neutral by clients, so new variants can ship server-side first.
+public static class CtaVariants
+{
+  public const string Manage = "manage";
+  public const string Subscribe = "subscribe";
+  public const string Neutral = "neutral";
+}
+
+// Thrown when a caller in a restricted storefront (neutral CTA) asks for a
+// handoff URL; mapped to 403 in AtomiControllerBase.MapException.
+public class HandoffNotAvailableException(string platform, string? storefront)
+  : Exception("Web handoff is not available for this platform/storefront")
+{
+  public string Platform { get; } = platform;
+  public string? Storefront { get; } = storefront;
+}
+
+public record SubscriptionCta(string Variant, string Tier);
+
+public record WebHandoff(string Url, int ExpiresInSeconds);
+
+public interface IWebHandoffService
+{
+  Task<Result<SubscriptionCta>> ResolveCta(string userId, string platform, string? storefront);
+
+  Task<Result<WebHandoff>> CreateHandoff(string userId, string platform, string? storefront);
+}
+
+// Pure steering-rule decision, extracted for direct unit testing. Allowlist
+// semantics: anything not explicitly permitted fails closed to Neutral.
+public static class CtaMatrix
+{
+  public static string Resolve(string tier, string platform, string? storefront,
+    IReadOnlyDictionary<string, CtaPlatformOption> cta)
+  {
+    if (tier != SubscriptionService.FreeTier) return CtaVariants.Manage;
+    if (string.IsNullOrWhiteSpace(storefront)) return CtaVariants.Neutral;
+    if (!cta.TryGetValue(platform.ToLowerInvariant(), out var p)) return CtaVariants.Neutral;
+    return p.SubscribeAllowed.Contains(storefront, StringComparer.OrdinalIgnoreCase)
+      ? CtaVariants.Subscribe
+      : CtaVariants.Neutral;
+  }
+}
+
+public class WebHandoffService(
+  ISubscriptionService subscriptionService,
+  IUserService userService,
+  IAuthManagement authManagement,
+  IOptionsMonitor<WebPortalOption> options,
+  ILogger<WebHandoffService> logger
+) : IWebHandoffService
+{
+  public Task<Result<SubscriptionCta>> ResolveCta(string userId, string platform, string? storefront)
+  {
+    var opt = options.CurrentValue;
+    return subscriptionService.GetUserTier(userId)
+      .Then(tier => new SubscriptionCta(CtaMatrix.Resolve(tier, platform, storefront, opt.Cta), tier),
+        Errors.MapNone);
+  }
+
+  public async Task<Result<WebHandoff>> CreateHandoff(string userId, string platform, string? storefront)
+  {
+    var opt = options.CurrentValue;
+
+    var ctaRes = await this.ResolveCta(userId, platform, storefront);
+    if (!ctaRes.IsSuccess()) return ctaRes.FailureOrDefault()!;
+    if (ctaRes.Get().Variant == CtaVariants.Neutral)
+      return new HandoffNotAvailableException(platform, storefront);
+
+    var userRes = await userService.GetById(userId);
+    if (!userRes.IsSuccess()) return userRes.FailureOrDefault()!;
+    var user = userRes.Get();
+    if (user == null)
+      return new NotFoundException("User not found", typeof(User), userId);
+
+    logger.LogInformation("Creating web handoff for user {UserId}", userId);
+    return await authManagement
+      .CreateOneTimeToken(user.Principal.Record.Email, opt.OttExpirySeconds)
+      .Then(token => new WebHandoff(BuildUrl(opt, token, user.Principal.Record.Email), opt.OttExpirySeconds),
+        Errors.MapNone);
+  }
+
+  // Query param names deliberately match Logto's signIn extraParams keys
+  // (one_time_token, login_hint) so the argon landing page can forward them
+  // verbatim; `redirect` is the same-origin path to land on after sign-in.
+  private static string BuildUrl(WebPortalOption opt, string token, string email)
+  {
+    var query = $"one_time_token={Uri.EscapeDataString(token)}"
+                + $"&login_hint={Uri.EscapeDataString(email)}"
+                + $"&redirect={Uri.EscapeDataString(opt.RedirectPath)}";
+    return $"{opt.Scheme}://{opt.Host}{opt.HandoffPath}?{query}";
+  }
+}

--- a/App/Modules/Auth/WebHandoffService.cs
+++ b/App/Modules/Auth/WebHandoffService.cs
@@ -1,5 +1,6 @@
 using App.StartUp.Options;
 using App.StartUp.Services.Auth;
+using App.Utility;
 using CSharp_Result;
 using Domain.Exceptions;
 using Domain.Subscription;
@@ -44,6 +45,10 @@ public static class CtaMatrix
   public static string Resolve(string tier, string platform, string? storefront,
     IReadOnlyDictionary<string, CtaPlatformOption> cta)
   {
+    // Any non-free tier (i.e. any active subscription row, even a legacy tier
+    // no longer in the catalog) may MANAGE: managing an existing subscription
+    // is permitted in every storefront — only the free-user "subscribe" steer
+    // below is region-gated, and that path is allowlist/fail-closed.
     if (tier != SubscriptionService.FreeTier) return CtaVariants.Manage;
     if (string.IsNullOrWhiteSpace(storefront)) return CtaVariants.Neutral;
     if (!cta.TryGetValue(platform.ToLowerInvariant(), out var p)) return CtaVariants.Neutral;
@@ -83,11 +88,16 @@ public class WebHandoffService(
     var user = userRes.Get();
     if (user == null)
       return new NotFoundException("User not found", typeof(User), userId);
+    var email = user.Principal.Record.Email;
+    if (string.IsNullOrWhiteSpace(email))
+      return new App.Error.V1.ValidationError(
+        "User has no email on record; a web login link cannot be minted",
+        new Dictionary<string, string[]> { ["email"] = ["missing"] }).ToException();
 
     logger.LogInformation("Creating web handoff for user {UserId}", userId);
     return await authManagement
-      .CreateOneTimeToken(user.Principal.Record.Email, opt.OttExpirySeconds)
-      .Then(token => new WebHandoff(BuildUrl(opt, token, user.Principal.Record.Email), opt.OttExpirySeconds),
+      .CreateOneTimeToken(email, opt.OttExpirySeconds)
+      .Then(token => new WebHandoff(BuildUrl(opt, token, email), opt.OttExpirySeconds),
         Errors.MapNone);
   }
 

--- a/App/Modules/Common/BaseController.cs
+++ b/App/Modules/Common/BaseController.cs
@@ -59,6 +59,8 @@ public class AtomiControllerBase(IAuthHelper h) : ControllerBase
         new NoActiveSubscription(nas.UserId)),
       SubscriptionBusyException sbe => this.Error(HttpStatusCode.Conflict,
         new RenewalInProgress(sbe.UserId)),
+      Auth.HandoffNotAvailableException hna => this.Error(HttpStatusCode.Forbidden,
+        new HandoffNotAvailable(hna.Platform, hna.Storefront)),
       _ => throw new AggregateException("Unhandled Exception", e),
     };
   }

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -123,6 +123,10 @@ public static class DomainServices
 
     s.AddScoped<IKonnectGateway, KonnectGateway>()
       .AutoTrace<IKonnectGateway>();
+
+    // WEB HANDOFF (neon app -> web billing portal magic link)
+    s.AddScoped<Auth.IWebHandoffService, Auth.WebHandoffService>()
+      .AutoTrace<Auth.IWebHandoffService>();
     // PAYMENT
     s.AddScoped<IPaymentService, PaymentService>()
       .AutoTrace<IPaymentService>();

--- a/App/Modules/Subscription/API/V1/SubscriptionController.cs
+++ b/App/Modules/Subscription/API/V1/SubscriptionController.cs
@@ -1,4 +1,6 @@
 using System.Net.Mime;
+using App.Modules.Auth;
+using App.Modules.Auth.API.V1;
 using App.Modules.Common;
 using App.StartUp.Services.Auth;
 using App.Utility;
@@ -17,11 +19,29 @@ namespace App.Modules.Subscription.API.V1;
 public class SubscriptionController(
   ISubscriptionRepository subscriptionRepository,
   ISubscriptionManagementService managementService,
+  IWebHandoffService webHandoffService,
   IAuthHelper authHelper,
   SubscribeReqValidator subscribeValidator,
-  ChangeTierReqValidator changeTierValidator
+  ChangeTierReqValidator changeTierValidator,
+  WebHandoffReqValidator webHandoffValidator
 ) : AtomiControllerBase(authHelper)
 {
+  // Which subscription CTA the app may show for this platform + storefront.
+  // Server-decided so steering rules can change per landscape without an app
+  // release; clients treat unknown variants as neutral.
+  [Authorize, HttpGet("{userId}/cta")]
+  public async Task<ActionResult<SubscriptionCtaRes>> Cta(string userId,
+    [FromQuery] string? platform, [FromQuery] string? storefront)
+  {
+    var result = await this.GuardAsync(userId)
+      .ThenAwait(_ => webHandoffValidator.ValidateAsyncResult(
+        new WebHandoffReq(platform ?? string.Empty, storefront), "Invalid CTA query"))
+      .ThenAwait(q => webHandoffService.ResolveCta(userId, q.Platform, q.Storefront))
+      .Then(c => new SubscriptionCtaRes(c.Variant, c.Tier), Errors.MapNone);
+
+    return this.ReturnResult(result);
+  }
+
   [Authorize, HttpGet("{userId}")]
   public async Task<ActionResult<SubscriptionRes>> Get(string userId)
   {

--- a/App/Modules/Subscription/API/V1/SubscriptionModel.cs
+++ b/App/Modules/Subscription/API/V1/SubscriptionModel.cs
@@ -8,6 +8,11 @@ public record ChangeTierReq(
   string Tier
 );
 
+public record SubscriptionCtaRes(
+  string Variant,
+  string Tier
+);
+
 public record SubscriptionRes(
   string UserId,
   string Tier,

--- a/App/StartUp/Options/OptionsExtensions.cs
+++ b/App/StartUp/Options/OptionsExtensions.cs
@@ -117,6 +117,11 @@ public static class OptionsExtensions
     // Register Error Portal Configurations
     services.RegisterOption<ErrorPortalOption>(ErrorPortalOption.Key);
 
+    // Register Web Portal (billing handoff) Configurations
+    services.RegisterOption<WebPortalOption>(WebPortalOption.Key)
+      .Validate(c => c.Cta.Keys.All(k => k is "ios" or "android"),
+        "WebPortal.Cta keys (Config File) must be 'ios' or 'android'");
+
     // Register Auth Configurations
     services.RegisterOption<AuthOption>(AuthOption.Key)
       .Validate(

--- a/App/StartUp/Options/WebPortalOption.cs
+++ b/App/StartUp/Options/WebPortalOption.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.StartUp.Options;
+
+// Web billing portal handoff: where the neon app's magic-link URL points, and
+// which storefronts may be shown the web "subscribe" link-out. Steering rules
+// differ per store region and shift with ongoing litigation, so the matrix
+// lives in per-landscape config, not code.
+public class WebPortalOption
+{
+  public const string Key = "WebPortal";
+
+  [Required, AllowedValues("http", "https")]
+  public string Scheme { get; set; } = string.Empty;
+
+  [Required] public string Host { get; set; } = string.Empty;
+
+  [Required] public string HandoffPath { get; set; } = "/auth/handoff";
+
+  [Required] public string RedirectPath { get; set; } = "/billing";
+
+  // Kept below Logto's 600s default: the token is a live login credential and
+  // is consumed within seconds of minting (tap -> browser).
+  [Range(30, 3600)] public int OttExpirySeconds { get; set; } = 300;
+
+  // Storefront allowlist per platform ("ios"/"android"): countries where a
+  // free user may see the "subscribe" link-out. Anything absent fails closed
+  // to the neutral CTA (no steering, no price comparison).
+  [Required] public Dictionary<string, CtaPlatformOption> Cta { get; set; } = [];
+}
+
+public class CtaPlatformOption
+{
+  [Required] public string[] SubscribeAllowed { get; set; } = [];
+}

--- a/App/StartUp/Services/Auth/AuthManagement.cs
+++ b/App/StartUp/Services/Auth/AuthManagement.cs
@@ -12,4 +12,6 @@ public interface IAuthManagement
   Task<Result<Unit>> RemoveClaim(string userId, string claimKey);
 
   Task<Result<Unit>> DeleteUser(string userId);
+
+  Task<Result<string>> CreateOneTimeToken(string email, int expiresInSeconds);
 }

--- a/App/StartUp/Services/Auth/Logto/LogtoAuthManagement.cs
+++ b/App/StartUp/Services/Auth/Logto/LogtoAuthManagement.cs
@@ -133,6 +133,40 @@ public class LogtoAuthManagement(
       }, Errors.MapNone);
   }
 
+  public Task<Result<string>> CreateOneTimeToken(string email, int expiresInSeconds)
+  {
+    // The email and the minted token are deliberately never logged: the token
+    // is a live login credential and the email identifies its owner.
+    logger.LogInformation("Minting one-time token, expiring in {ExpiresInSeconds}s", expiresInSeconds);
+    return authenticator.BearerToken()
+      .ThenAwait(async bearer =>
+      {
+        try
+        {
+          var request = new HttpRequestMessage
+          {
+            Method = HttpMethod.Post,
+            RequestUri = new Uri("api/one-time-tokens", UriKind.Relative),
+            Headers = { Authorization = new AuthenticationHeaderValue("Bearer", bearer), },
+            Content = new StringContent(
+              new LogtoOneTimeTokenReq { Email = email, ExpiresIn = expiresInSeconds }.ToJson(),
+              Encoding.UTF8, "application/json")
+          };
+          using var response = await this.HttpClient.SendAsync(request);
+          response.EnsureSuccessStatusCode();
+          var body = await response.Content.ReadAsStringAsync();
+          var r = body.ToObj<LogtoOneTimeTokenRes>();
+          logger.LogInformation("One-time token minted");
+          return r.Token;
+        }
+        catch (Exception e)
+        {
+          logger.LogError(e, "Failed to mint one-time token");
+          throw;
+        }
+      }, Errors.MapNone);
+  }
+
   public Task<Result<Unit>> DeleteUser(string userId)
   {
     logger.LogInformation("Deleting user {UserId} from Logto", userId);

--- a/App/StartUp/Services/Auth/Logto/Models.cs
+++ b/App/StartUp/Services/Auth/Logto/Models.cs
@@ -18,6 +18,22 @@ public record LogtoTokenRes
   [JsonPropertyName("scope")] public string Scope { get; set; } = string.Empty;
 }
 
+public record LogtoOneTimeTokenReq
+{
+  [JsonPropertyName("email")] public string Email { get; set; } = string.Empty;
+
+  [JsonPropertyName("expiresIn")] public int ExpiresIn { get; set; }
+}
+
+public record LogtoOneTimeTokenRes
+{
+  [JsonPropertyName("token")] public string Token { get; set; } = string.Empty;
+
+  [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+
+  [JsonPropertyName("expiresAt")] public long ExpiresAt { get; set; }
+}
+
 public record ClaimsPatchReq
 {
   [JsonPropertyName("customData")] public Dictionary<string, string?> CustomData { get; set; } = [];

--- a/UnitTest/Handoff/CtaMatrixTests.cs
+++ b/UnitTest/Handoff/CtaMatrixTests.cs
@@ -1,0 +1,78 @@
+using App.Modules.Auth;
+using App.StartUp.Options;
+
+namespace UnitTest.Handoff;
+
+// The pure steering-rule decision: paid -> manage everywhere; free -> subscribe
+// only in explicitly allowlisted storefronts; everything else fails closed to
+// neutral (compliance-safe default for restricted regions like SG).
+public class CtaMatrixTests
+{
+  private static Dictionary<string, CtaPlatformOption> Cta(
+    string[]? ios = null, string[]? android = null) => new()
+  {
+    ["ios"] = new CtaPlatformOption { SubscribeAllowed = ios ?? [] },
+    ["android"] = new CtaPlatformOption { SubscribeAllowed = android ?? [] },
+  };
+
+  [Theory]
+  [InlineData("US")]
+  [InlineData("SG")]
+  [InlineData(null)]
+  public void PaidTier_IsManage_RegardlessOfStorefront(string? storefront)
+  {
+    CtaMatrix.Resolve("pro", "ios", storefront, Cta(ios: ["US"]))
+      .Should().Be(CtaVariants.Manage);
+  }
+
+  [Fact]
+  public void FreeTier_AllowlistedStorefront_IsSubscribe()
+  {
+    CtaMatrix.Resolve("free", "ios", "US", Cta(ios: ["US", "DE"]))
+      .Should().Be(CtaVariants.Subscribe);
+  }
+
+  [Fact]
+  public void FreeTier_StorefrontCaseInsensitive()
+  {
+    CtaMatrix.Resolve("free", "ios", "us", Cta(ios: ["US"]))
+      .Should().Be(CtaVariants.Subscribe);
+  }
+
+  [Theory]
+  [InlineData("SG")]
+  [InlineData("BR")]
+  [InlineData("XX")]
+  public void FreeTier_UnlistedStorefront_IsNeutral(string storefront)
+  {
+    CtaMatrix.Resolve("free", "ios", storefront, Cta(ios: ["US", "DE"]))
+      .Should().Be(CtaVariants.Neutral);
+  }
+
+  [Theory]
+  [InlineData(null)]
+  [InlineData("")]
+  [InlineData(" ")]
+  public void FreeTier_MissingStorefront_FailsClosedToNeutral(string? storefront)
+  {
+    CtaMatrix.Resolve("free", "ios", storefront, Cta(ios: ["US"]))
+      .Should().Be(CtaVariants.Neutral);
+  }
+
+  [Fact]
+  public void FreeTier_UnknownPlatform_FailsClosedToNeutral()
+  {
+    CtaMatrix.Resolve("free", "windows", "US", Cta(ios: ["US"]))
+      .Should().Be(CtaVariants.Neutral);
+  }
+
+  [Fact]
+  public void PlatformAllowlists_AreIndependent()
+  {
+    var cta = Cta(ios: ["US"], android: ["DE"]);
+    CtaMatrix.Resolve("free", "ios", "US", cta).Should().Be(CtaVariants.Subscribe);
+    CtaMatrix.Resolve("free", "android", "US", cta).Should().Be(CtaVariants.Neutral);
+    CtaMatrix.Resolve("free", "android", "DE", cta).Should().Be(CtaVariants.Subscribe);
+    CtaMatrix.Resolve("free", "ios", "DE", cta).Should().Be(CtaVariants.Neutral);
+  }
+}

--- a/UnitTest/Handoff/Fakes.cs
+++ b/UnitTest/Handoff/Fakes.cs
@@ -1,0 +1,111 @@
+using App.StartUp.Options;
+using App.StartUp.Services.Auth;
+using CSharp_Result;
+using Domain.Subscription;
+using Domain.User;
+using Microsoft.Extensions.Options;
+using DomainUser = Domain.User.User;
+
+namespace UnitTest.Handoff;
+
+// Hand-rolled fakes implementing the real contracts (no Moq, matching the
+// UnitTest/Subscription style) for the web-handoff service tests.
+
+public sealed class FakeSubscriptionService(string tier) : ISubscriptionService
+{
+  public List<string> Calls { get; } = [];
+
+  public Task<Result<string>> GetUserTier(string userId)
+  {
+    Calls.Add($"GetUserTier({userId})");
+    return Task.FromResult<Result<string>>(tier);
+  }
+
+  public Task<Result<int>> GetLimitForTier(string tier1, string key) =>
+    Task.FromResult<Result<int>>(int.MaxValue);
+}
+
+public sealed class FakeUserService(DomainUser? user) : IUserService
+{
+  public List<string> Calls { get; } = [];
+
+  public Task<Result<DomainUser?>> GetById(string id)
+  {
+    Calls.Add($"GetById({id})");
+    return Task.FromResult<Result<DomainUser?>>(user);
+  }
+
+  public Task<Result<IEnumerable<UserPrincipal>>> Search(UserSearch search) =>
+    throw new NotImplementedException();
+
+  public Task<Result<DomainUser?>> GetByUsername(string username) => throw new NotImplementedException();
+
+  public Task<Result<UserPrincipal>> Create(string id, UserRecord record, Func<Task<Result<Unit>>>? sync) =>
+    throw new NotImplementedException();
+
+  public Task<Result<UserPrincipal?>> Update(string id, UserRecord record, Func<Task<Result<Unit>>>? sync) =>
+    throw new NotImplementedException();
+
+  public Task<Result<Unit?>> Delete(string id) => throw new NotImplementedException();
+
+  public Task<Result<Unit?>> DeleteAllRemnants(string id) => throw new NotImplementedException();
+
+  public Task<Result<Unit?>> DeleteAccount(string id, bool blockOnDebt,
+    Func<Task<Result<Unit>>>? onBeforePurge = null) => throw new NotImplementedException();
+}
+
+public sealed class FakeAuthManagement : IAuthManagement
+{
+  private readonly Result<string> _tokenResult;
+
+  public List<(string Email, int ExpiresInSeconds)> CreateOneTimeTokenCalls { get; } = [];
+
+  public FakeAuthManagement(string token) => _tokenResult = token;
+
+  public FakeAuthManagement(Exception failure) => _tokenResult = failure;
+
+  public Task<Result<string>> CreateOneTimeToken(string email, int expiresInSeconds)
+  {
+    CreateOneTimeTokenCalls.Add((email, expiresInSeconds));
+    return Task.FromResult(_tokenResult);
+  }
+
+  public Task<Result<Unit>> AssignRole(string userId, string roleId) => throw new NotImplementedException();
+
+  public Task<Result<Unit>> RemoveRole(string userId, string roleId) => throw new NotImplementedException();
+
+  public Task<Result<Unit>> SetClaim(string userId, string claimKey, string claimValue) =>
+    throw new NotImplementedException();
+
+  public Task<Result<Unit>> RemoveClaim(string userId, string claimKey) => throw new NotImplementedException();
+
+  public Task<Result<Unit>> DeleteUser(string userId) => throw new NotImplementedException();
+}
+
+public sealed class FakeOptionsMonitor(WebPortalOption value) : IOptionsMonitor<WebPortalOption>
+{
+  public WebPortalOption CurrentValue => value;
+
+  public WebPortalOption Get(string? name) => value;
+
+  public IDisposable? OnChange(Action<WebPortalOption, string?> listener) => null;
+}
+
+public static class Users
+{
+  public static DomainUser Make(string id, string email) => new()
+  {
+    Principal = new UserPrincipal
+    {
+      Id = id,
+      Record = new UserRecord
+      {
+        Username = "testuser",
+        Email = email,
+        EmailVerified = true,
+        Active = true,
+        Scopes = [],
+      },
+    },
+  };
+}

--- a/UnitTest/Handoff/WebHandoffServiceTests.cs
+++ b/UnitTest/Handoff/WebHandoffServiceTests.cs
@@ -1,0 +1,150 @@
+using App.Modules.Auth;
+using App.StartUp.Options;
+using Domain.Exceptions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTest.Handoff;
+
+// WebHandoffService: URL composition/encoding, expiry passthrough, and the
+// guard rails (neutral callers refused, missing user -> not found, Logto
+// failures propagate as failed Results).
+public class WebHandoffServiceTests
+{
+  private const string Sub = "user-sub-1";
+
+  private static WebPortalOption Opt(string[]? ios = null) => new()
+  {
+    Scheme = "https",
+    Host = "portal.example.com",
+    HandoffPath = "/auth/handoff",
+    RedirectPath = "/billing",
+    OttExpirySeconds = 300,
+    Cta = new Dictionary<string, CtaPlatformOption>
+    {
+      ["ios"] = new() { SubscribeAllowed = ios ?? ["US"] },
+      ["android"] = new() { SubscribeAllowed = [] },
+    },
+  };
+
+  private static WebHandoffService Svc(
+    string tier = "free",
+    Domain.User.User? user = null,
+    FakeAuthManagement? auth = null,
+    WebPortalOption? opt = null)
+    => new(
+      new FakeSubscriptionService(tier),
+      new FakeUserService(user),
+      auth ?? new FakeAuthManagement("tok"),
+      new FakeOptionsMonitor(opt ?? Opt()),
+      NullLogger<WebHandoffService>.Instance);
+
+  [Fact]
+  public async Task CreateHandoff_ComposesMagicLinkUrl()
+  {
+    var auth = new FakeAuthManagement("the-token");
+    var svc = Svc(user: Users.Make(Sub, "testuser@lazytax.club"), auth: auth);
+
+    var result = await svc.CreateHandoff(Sub, "ios", "US");
+
+    result.IsSuccess().Should().BeTrue();
+    var handoff = (WebHandoff)result;
+    handoff.Url.Should().Be(
+      "https://portal.example.com/auth/handoff"
+      + "?one_time_token=the-token"
+      + "&login_hint=testuser%40lazytax.club"
+      + "&redirect=%2Fbilling");
+    handoff.ExpiresInSeconds.Should().Be(300);
+  }
+
+  [Fact]
+  public async Task CreateHandoff_EncodesPlusInEmail()
+  {
+    var svc = Svc(user: Users.Make(Sub, "test+tag@lazytax.club"));
+
+    var result = await svc.CreateHandoff(Sub, "ios", "US");
+
+    ((WebHandoff)result).Url.Should().Contain("login_hint=test%2Btag%40lazytax.club");
+  }
+
+  [Fact]
+  public async Task CreateHandoff_PassesConfiguredExpiryToLogto()
+  {
+    var auth = new FakeAuthManagement("tok");
+    var opt = Opt();
+    opt.OttExpirySeconds = 120;
+    var svc = Svc(user: Users.Make(Sub, "a@b.co"), auth: auth, opt: opt);
+
+    var result = await svc.CreateHandoff(Sub, "ios", "US");
+
+    result.IsSuccess().Should().BeTrue();
+    auth.CreateOneTimeTokenCalls.Should().ContainSingle()
+      .Which.Should().Be(("a@b.co", 120));
+    ((WebHandoff)result).ExpiresInSeconds.Should().Be(120);
+  }
+
+  [Fact]
+  public async Task CreateHandoff_PaidUserInRestrictedStorefront_StillAllowed()
+  {
+    var svc = Svc(tier: "pro", user: Users.Make(Sub, "a@b.co"));
+
+    var result = await svc.CreateHandoff(Sub, "ios", "SG");
+
+    result.IsSuccess().Should().BeTrue();
+  }
+
+  [Fact]
+  public async Task CreateHandoff_NeutralCaller_IsRefused()
+  {
+    var auth = new FakeAuthManagement("tok");
+    var svc = Svc(user: Users.Make(Sub, "a@b.co"), auth: auth);
+
+    var result = await svc.CreateHandoff(Sub, "ios", "SG");
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<HandoffNotAvailableException>();
+    auth.CreateOneTimeTokenCalls.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task CreateHandoff_MissingUser_IsNotFound()
+  {
+    var svc = Svc(user: null);
+
+    var result = await svc.CreateHandoff(Sub, "ios", "US");
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().BeOfType<NotFoundException>();
+  }
+
+  [Fact]
+  public async Task CreateHandoff_LogtoFailure_PropagatesAsFailedResult()
+  {
+    var boom = new HttpRequestException("logto down");
+    var svc = Svc(user: Users.Make(Sub, "a@b.co"), auth: new FakeAuthManagement(boom));
+
+    var result = await svc.CreateHandoff(Sub, "ios", "US");
+
+    result.IsSuccess().Should().BeFalse();
+    result.FailureOrDefault().Should().Be(boom);
+  }
+
+  [Fact]
+  public async Task ResolveCta_ReturnsVariantAndTier()
+  {
+    var svc = Svc(tier: "pro");
+
+    var result = await svc.ResolveCta(Sub, "ios", "SG");
+
+    ((SubscriptionCta)result).Should().Be(new SubscriptionCta(CtaVariants.Manage, "pro"));
+  }
+
+  [Fact]
+  public async Task ResolveCta_FreeRestricted_IsNeutral()
+  {
+    var svc = Svc(tier: "free");
+
+    var result = await svc.ResolveCta(Sub, "ios", "SG");
+
+    ((SubscriptionCta)result).Should().Be(new SubscriptionCta(CtaVariants.Neutral, "free"));
+  }
+}

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -1001,7 +1001,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["Scheme", "Host"]
     },
     "Auth": {
       "title": "AuthOption",

--- a/infra/api_chart/app/schema.json
+++ b/infra/api_chart/app/schema.json
@@ -34,6 +34,9 @@
     "ErrorPortal": {
       "$ref": "#/definitions/ErrorPortal"
     },
+    "WebPortal": {
+      "$ref": "#/definitions/WebPortal"
+    },
     "Auth": {
       "$ref": "#/definitions/Auth"
     },
@@ -942,6 +945,61 @@
         "Host": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "WebPortal": {
+      "title": "WebPortalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Scheme": {
+          "type": "string",
+          "enum": ["http", "https"]
+        },
+        "Host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "HandoffPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "RedirectPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "OttExpirySeconds": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 3600
+        },
+        "Cta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ios": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            },
+            "android": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            }
+          }
+        }
+      },
+      "definitions": {
+        "CtaPlatform": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SubscribeAllowed": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$"
+              }
+            }
+          }
         }
       }
     },

--- a/infra/api_chart/app/settings.example.yaml
+++ b/infra/api_chart/app/settings.example.yaml
@@ -132,6 +132,17 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+WebPortal:
+  Scheme: https
+  Host: portal.example.com
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed: [US]
+    android:
+      SubscribeAllowed: [US]
 Database:
   Main:
     Host: zinc-maindb

--- a/infra/api_chart/app/settings.pichu.yaml
+++ b/infra/api_chart/app/settings.pichu.yaml
@@ -49,6 +49,10 @@ HttpClient:
 Disbursement:
   Enabled: true
 
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pichu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/api_chart/app/settings.pikachu.yaml
+++ b/infra/api_chart/app/settings.pikachu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pikachu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/api_chart/app/settings.raichu.yaml
+++ b/infra/api_chart/app/settings.raichu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: lazytax.club
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -41,6 +41,23 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+# Web billing portal handoff (neon app -> browser magic link). Scheme/Host are
+# the argon portal for the landscape; the Cta allowlists are the storefronts
+# where a free user may see the web "subscribe" link-out (US: Epic ruling,
+# EU-27: DMA). Anything not listed (incl. SG) fails closed to the neutral CTA.
+WebPortal:
+  Scheme: http
+  Host: localhost:3000
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
+    android:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
 # Security
 Cors:
   - Name: AllowAll

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -1001,7 +1001,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["Scheme", "Host"]
     },
     "Auth": {
       "title": "AuthOption",

--- a/infra/migration_chart/app/schema.json
+++ b/infra/migration_chart/app/schema.json
@@ -34,6 +34,9 @@
     "ErrorPortal": {
       "$ref": "#/definitions/ErrorPortal"
     },
+    "WebPortal": {
+      "$ref": "#/definitions/WebPortal"
+    },
     "Auth": {
       "$ref": "#/definitions/Auth"
     },
@@ -942,6 +945,61 @@
         "Host": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "WebPortal": {
+      "title": "WebPortalOption",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Scheme": {
+          "type": "string",
+          "enum": ["http", "https"]
+        },
+        "Host": {
+          "type": "string",
+          "minLength": 1
+        },
+        "HandoffPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "RedirectPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "OttExpirySeconds": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 3600
+        },
+        "Cta": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ios": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            },
+            "android": {
+              "$ref": "#/definitions/WebPortal/definitions/CtaPlatform"
+            }
+          }
+        }
+      },
+      "definitions": {
+        "CtaPlatform": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SubscribeAllowed": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Z]{2}$"
+              }
+            }
+          }
         }
       }
     },

--- a/infra/migration_chart/app/settings.example.yaml
+++ b/infra/migration_chart/app/settings.example.yaml
@@ -132,6 +132,17 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+WebPortal:
+  Scheme: https
+  Host: portal.example.com
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed: [US]
+    android:
+      SubscribeAllowed: [US]
 Database:
   Main:
     Host: zinc-maindb

--- a/infra/migration_chart/app/settings.pichu.yaml
+++ b/infra/migration_chart/app/settings.pichu.yaml
@@ -49,6 +49,10 @@ HttpClient:
 Disbursement:
   Enabled: true
 
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pichu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/migration_chart/app/settings.pikachu.yaml
+++ b/infra/migration_chart/app/settings.pikachu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: argon-alcohol-pikachu.kirinnee.workers.dev
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/migration_chart/app/settings.raichu.yaml
+++ b/infra/migration_chart/app/settings.raichu.yaml
@@ -39,6 +39,10 @@ HttpClient:
     BaseAddress: https://api.pledge.to
     Timeout: 60
     BearerAuth: supersecret
+WebPortal:
+  Scheme: https
+  Host: lazytax.club
+
 Auth:
   Enabled: true
   Settings:

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -41,6 +41,23 @@ ErrorPortal:
   Scheme: http
   Host: localhost:3000
   EnableExceptionResponse: true
+# Web billing portal handoff (neon app -> browser magic link). Scheme/Host are
+# the argon portal for the landscape; the Cta allowlists are the storefronts
+# where a free user may see the web "subscribe" link-out (US: Epic ruling,
+# EU-27: DMA). Anything not listed (incl. SG) fails closed to the neutral CTA.
+WebPortal:
+  Scheme: http
+  Host: localhost:3000
+  HandoffPath: /auth/handoff
+  RedirectPath: /billing
+  OttExpirySeconds: 300
+  Cta:
+    ios:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
+    android:
+      SubscribeAllowed:
+        [US, AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE]
 # Security
 Cors:
   - Name: AllowAll

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -20,7 +20,7 @@ TOKEN=$(
   scripts/e2e/get-user-token.sh
 )
 curl -H "Authorization: Bearer $TOKEN" \
-  https://api.zinc.alcohol.pichu.cluster.atomi.cloud/api/v1/subscription/<userId>
+  https://api.zinc.alcohol.pichu.cluster.atomi.cloud/api/v1.0/Subscription/<userId>
 ```
 
 Notes:

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,57 @@
+# E2E test tooling
+
+## `get-user-token.sh` — real user tokens without a browser
+
+Mints a genuine Logto user access token via impersonation
+([docs](https://docs.logto.io/developers/user-impersonation)): M2M creds →
+management token → subject token for the target user → OAuth token exchange.
+zinc cannot tell the result apart from a normal login token.
+
+### Usage
+
+```bash
+TOKEN=$(
+  LOGTO_ENDPOINT=https://api.lithium.alcohol.pichu.cluster.atomi.cloud \
+  LOGTO_M2M_ID=<management m2m app id> \
+  LOGTO_M2M_SECRET=<management m2m secret> \
+  EXCHANGE_APP_ID=<user-facing app id, e.g. the alcohol.neon Native app> \
+  API_RESOURCE=https://api.zinc.alcohol.pichu \
+  USER_EMAIL=testuser@lazytax.club \
+  scripts/e2e/get-user-token.sh
+)
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.zinc.alcohol.pichu.cluster.atomi.cloud/api/v1/subscription/<userId>
+```
+
+Notes:
+
+- On lithium's current Logto version, the token-exchange grant works for
+  **user-facing** apps (Native/SPA/Traditional) and is rejected for M2M apps.
+  Native apps are public clients — `EXCHANGE_APP_SECRET` is not needed.
+- The script prints ONLY the token on stdout; all diagnostics go to stderr.
+
+### Security handling rules
+
+The script contains no credentials, but it consumes one powerful secret and
+emits one live token. Handle both accordingly:
+
+1. **`LOGTO_M2M_SECRET` is the Management API key** — whoever holds it can
+   administer all users. In CI, store it as a GitHub Actions **secret**
+   (auto-masked); locally, pull it from Infisical into the environment, never
+   into files or shell history.
+2. **Never log the output token.** Capture it into a variable; in GitHub
+   Actions, `echo "::add-mask::$TOKEN"` immediately after capture. Never run
+   the script under `set -x`.
+3. **Blast radius**: the token is short-lived and belongs to a dedicated test
+   user — keep it that way. Do not impersonate real users in tests.
+4. **pichu-only policy.** Do not wire raichu (production) management secrets
+   into any automated job. Production impersonation must remain a deliberate,
+   manual, audited act.
+
+### Test identities (pichu)
+
+| What | Value |
+| ------------------ | ----------------------------------------- |
+| Test user | `testuser@lazytax.club` (`tajahe2jbu4f`) |
+| Exchange app | alcohol.neon Native (public) |
+| Management M2M app | zinc's `Auth.Management` (Id from config, secret in Infisical `ATOMI_AUTH__MANAGEMENT__SECRET`) |

--- a/scripts/e2e/get-user-token.sh
+++ b/scripts/e2e/get-user-token.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Mint a REAL user access token via Logto impersonation (token exchange),
+# without any browser or password — for automated E2E tests against a live
+# landscape. https://docs.logto.io/developers/user-impersonation
+#
+#   M2M creds ──▶ management token ──▶ POST /api/subject-tokens {userId}
+#             ──▶ POST /oidc/token (grant_type=token-exchange) ──▶ user JWT
+#
+# The resulting token is indistinguishable from a normal login token: same
+# issuer, audience and claims — zinc's auth accepts it as the user.
+#
+# Required env:
+#   LOGTO_ENDPOINT        e.g. https://api.lithium.alcohol.pichu.cluster.atomi.cloud
+#   LOGTO_M2M_ID          management M2M app id   (zinc's Auth.Management.Id works)
+#   LOGTO_M2M_SECRET      management M2M app secret
+#   EXCHANGE_APP_ID       app used for the exchange. On lithium's current Logto
+#                         version, USER-FACING apps (Native/SPA/Traditional)
+#                         accept the token-exchange grant out of the box, while
+#                         M2M apps reject it — use e.g. the alcohol.neon Native
+#                         app id. Verified on pichu 2026-07-04.
+#   EXCHANGE_APP_SECRET   its secret (omit for public apps like Native)
+#   API_RESOURCE          audience, e.g. https://api.zinc.alcohol.pichu
+#   USER_ID               Logto user id to impersonate (or set USER_EMAIL)
+# Optional:
+#   USER_EMAIL            resolved to USER_ID via the Management API
+#   MGMT_RESOURCE         default https://default.logto.app/api (self-hosted)
+#   SCOPES                extra scopes for the user token (space-separated)
+#
+# Output: the user access token on stdout (nothing else), so callers can do
+#   TOKEN=$(scripts/e2e/get-user-token.sh)
+set -euo pipefail
+
+: "${LOGTO_ENDPOINT:?}" "${LOGTO_M2M_ID:?}" "${LOGTO_M2M_SECRET:?}"
+: "${EXCHANGE_APP_ID:?}" "${API_RESOURCE:?}"
+MGMT_RESOURCE="${MGMT_RESOURCE:-https://default.logto.app/api}"
+
+err() {
+  echo "get-user-token: $*" >&2
+  exit 1
+}
+need() { command -v "$1" >/dev/null || err "missing dependency: $1"; }
+need curl
+need jq
+
+# 1. Management token (client credentials) — the part that IS automatable today.
+mgmt_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/oidc/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "$LOGTO_M2M_ID:$LOGTO_M2M_SECRET" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "resource=$MGMT_RESOURCE" \
+  --data-urlencode "scope=all" | jq -r .access_token) || err "management token request failed"
+if [ -z "$mgmt_token" ] || [ "$mgmt_token" = "null" ]; then err "no management token in response"; fi
+
+# 2. Resolve email -> user id if needed.
+if [ -z "${USER_ID:-}" ]; then
+  : "${USER_EMAIL:?set USER_ID or USER_EMAIL}"
+  USER_ID=$(curl -sf "$LOGTO_ENDPOINT/api/users?search=$(jq -rn --arg e "$USER_EMAIL" '$e|@uri')" \
+    -H "Authorization: Bearer $mgmt_token" |
+    jq -r --arg e "$USER_EMAIL" '.[] | select(.primaryEmail==$e) | .id' | head -1)
+  [ -n "$USER_ID" ] || err "no user found for $USER_EMAIL"
+fi
+
+# 3. Subject token for the target user (Management API; short-lived, single-use).
+subject_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/api/subject-tokens" \
+  -H "Authorization: Bearer $mgmt_token" -H "Content-Type: application/json" \
+  -d "{\"userId\": \"$USER_ID\"}" | jq -r .subjectToken) || err "subject-token request failed (Logto too old, or missing permission)"
+if [ -z "$subject_token" ] || [ "$subject_token" = "null" ]; then err "no subjectToken in response"; fi
+
+# 4. Exchange it for a real user access token scoped to the API resource.
+auth_args=(-u "$EXCHANGE_APP_ID:${EXCHANGE_APP_SECRET:-}")
+[ -z "${EXCHANGE_APP_SECRET:-}" ] && auth_args=(--data-urlencode "client_id=$EXCHANGE_APP_ID")
+user_token=$(curl -sf -X POST "$LOGTO_ENDPOINT/oidc/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  "${auth_args[@]}" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=$subject_token" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  --data-urlencode "resource=$API_RESOURCE" \
+  ${SCOPES:+--data-urlencode "scope=$SCOPES"} |
+  jq -r .access_token) || err "token exchange failed (is the grant enabled on $EXCHANGE_APP_ID?)"
+if [ -z "$user_token" ] || [ "$user_token" = "null" ]; then err "no access_token in exchange response"; fi
+
+echo "$user_token"

--- a/scripts/e2e/web-handoff.sh
+++ b/scripts/e2e/web-handoff.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# E2E for the neon->web handoff (POST /api/v1.0/Auth/web-handoff) against a
+# live landscape (pichu). Proves the acceptance criteria that don't need a
+# browser: the endpoint is authed, returns a well-formed magic-link URL whose
+# one-time token is REAL and SINGLE-USE, and the CTA matrix resolves per
+# storefront with restricted regions failing closed.
+#
+# Security: same rules as get-user-token.sh (see README.md) — the user token
+# and the minted OTT are live credentials; neither is ever echoed. pichu only.
+#
+# Required env (same as get-user-token.sh):
+#   LOGTO_ENDPOINT, LOGTO_M2M_ID, LOGTO_M2M_SECRET, EXCHANGE_APP_ID, API_RESOURCE
+# Optional:
+#   ZINC_ENDPOINT   default https://api.zinc.alcohol.pichu.cluster.atomi.cloud
+#   USER_EMAIL      default testuser@lazytax.club
+#   MGMT_RESOURCE   default https://default.logto.app/api
+set -euo pipefail
+
+: "${LOGTO_ENDPOINT:?}" "${LOGTO_M2M_ID:?}" "${LOGTO_M2M_SECRET:?}"
+ZINC_ENDPOINT="${ZINC_ENDPOINT:-https://api.zinc.alcohol.pichu.cluster.atomi.cloud}"
+USER_EMAIL="${USER_EMAIL:-testuser@lazytax.club}"
+MGMT_RESOURCE="${MGMT_RESOURCE:-https://default.logto.app/api}"
+
+pass=0
+fail=0
+ok() {
+  echo "  ✅ $1" >&2
+  pass=$((pass + 1))
+}
+ko() {
+  echo "  ❌ $1" >&2
+  fail=$((fail + 1))
+}
+
+need() { command -v "$1" >/dev/null || {
+  echo "missing dependency: $1" >&2
+  exit 1
+}; }
+need curl
+need jq
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "== minting user token for $USER_EMAIL ==" >&2
+TOKEN=$(USER_EMAIL="$USER_EMAIL" "$here/get-user-token.sh")
+sub=$(echo "$TOKEN" | cut -d. -f2 | tr '_-' '/+' | {
+  p=$(cat)
+  pad=$(((4 - ${#p} % 4) % 4))
+  printf '%s' "$p"
+  printf '=%.0s' $(seq 1 $pad) 2>/dev/null
+} | base64 -d 2>/dev/null | jq -r .sub)
+if [ -z "$sub" ] || [ "$sub" = "null" ]; then
+  echo "could not extract sub from token" >&2
+  exit 1
+fi
+echo "== caller sub: $sub ==" >&2
+
+echo "== management token (for OTT verification) ==" >&2
+mgmt=$(curl -sf -X POST "$LOGTO_ENDPOINT/oidc/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "$LOGTO_M2M_ID:$LOGTO_M2M_SECRET" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "resource=$MGMT_RESOURCE" \
+  --data-urlencode "scope=all" | jq -r .access_token)
+
+echo "== 1. POST /api/v1.0/Auth/web-handoff (ios, US) ==" >&2
+res=$(curl -s -w '\n%{http_code}' -X POST "$ZINC_ENDPOINT/api/v1.0/Auth/web-handoff" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"platform": "ios", "storefront": "US"}')
+code=$(echo "$res" | tail -1)
+body=$(echo "$res" | sed '$d')
+url=$(echo "$body" | jq -r '.url // empty')
+if [ "$code" = "200" ] && [[ $url =~ ^https://.+/auth/handoff\?one_time_token=.+\&login_hint=.+\&redirect=.+$ ]]; then
+  ok "handoff returned 200 with well-formed magic-link URL"
+else
+  ko "handoff failed: HTTP $code, url shape mismatch"
+fi
+
+ott=$(echo "$url" | sed -n 's/.*one_time_token=\([^&]*\).*/\1/p')
+if [ -n "$ott" ]; then
+  echo "== 2. OTT is real + single-use (verify twice on lithium) ==" >&2
+  v1=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$LOGTO_ENDPOINT/api/one-time-tokens/verify" \
+    -H "Authorization: Bearer $mgmt" -H "Content-Type: application/json" \
+    -d "{\"email\": \"$USER_EMAIL\", \"token\": \"$ott\"}")
+  v2=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$LOGTO_ENDPOINT/api/one-time-tokens/verify" \
+    -H "Authorization: Bearer $mgmt" -H "Content-Type: application/json" \
+    -d "{\"email\": \"$USER_EMAIL\", \"token\": \"$ott\"}")
+  if [ "$v1" = "200" ]; then ok "OTT verified as real (200)"; else ko "OTT verify returned $v1"; fi
+  if [ "$v2" != "200" ]; then ok "OTT is single-use (2nd verify: $v2)"; else ko "OTT verified twice — not single-use"; fi
+fi
+
+echo "== 3. CTA matrix ==" >&2
+tier=$(curl -sf "$ZINC_ENDPOINT/api/v1.0/Subscription/$sub" -H "Authorization: Bearer $TOKEN" | jq -r .tier)
+echo "   (caller tier: $tier)" >&2
+cta_sg=$(curl -sf "$ZINC_ENDPOINT/api/v1.0/Subscription/$sub/cta?platform=ios&storefront=SG" \
+  -H "Authorization: Bearer $TOKEN" | jq -r .variant)
+cta_us=$(curl -sf "$ZINC_ENDPOINT/api/v1.0/Subscription/$sub/cta?platform=ios&storefront=US" \
+  -H "Authorization: Bearer $TOKEN" | jq -r .variant)
+if [ "$tier" = "free" ]; then
+  if [ "$cta_sg" = "neutral" ]; then ok "free + SG storefront -> neutral"; else ko "free + SG -> $cta_sg (want neutral)"; fi
+  if [ "$cta_us" = "subscribe" ]; then ok "free + US storefront -> subscribe"; else ko "free + US -> $cta_us (want subscribe)"; fi
+else
+  if [ "$cta_sg" = "manage" ]; then ok "paid + SG storefront -> manage"; else ko "paid + SG -> $cta_sg (want manage)"; fi
+  if [ "$cta_us" = "manage" ]; then ok "paid + US storefront -> manage"; else ko "paid + US -> $cta_us (want manage)"; fi
+fi
+
+echo "== 4. own-account guard (CTA for another user must 403) ==" >&2
+guard=$(curl -s -o /dev/null -w '%{http_code}' \
+  "$ZINC_ENDPOINT/api/v1.0/Subscription/someone-else/cta?platform=ios&storefront=US" \
+  -H "Authorization: Bearer $TOKEN")
+if [ "$guard" = "403" ]; then ok "cross-user CTA rejected (403)"; else ko "cross-user CTA returned $guard (want 403)"; fi
+
+echo "== 5. unauthenticated handoff must 401 ==" >&2
+anon=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$ZINC_ENDPOINT/api/v1.0/Auth/web-handoff" \
+  -H "Content-Type: application/json" -d '{"platform": "ios", "storefront": "US"}')
+if [ "$anon" = "401" ]; then ok "anonymous handoff rejected (401)"; else ko "anonymous handoff returned $anon (want 401)"; fi
+
+echo >&2
+echo "== results: $pass passed, $fail failed ==" >&2
+[ "$fail" = "0" ]

--- a/scripts/e2e/web-handoff.sh
+++ b/scripts/e2e/web-handoff.sh
@@ -47,7 +47,7 @@ sub=$(echo "$TOKEN" | cut -d. -f2 | tr '_-' '/+' | {
   p=$(cat)
   pad=$(((4 - ${#p} % 4) % 4))
   printf '%s' "$p"
-  printf '=%.0s' $(seq 1 $pad) 2>/dev/null
+  if [ "$pad" -gt 0 ]; then printf '=%.0s' $(seq 1 "$pad"); fi
 } | base64 -d 2>/dev/null | jq -r .sub)
 if [ -z "$sub" ] || [ "$sub" = "null" ]; then
   echo "could not extract sub from token" >&2
@@ -102,6 +102,14 @@ if [ "$tier" = "free" ]; then
 else
   if [ "$cta_sg" = "manage" ]; then ok "paid + SG storefront -> manage"; else ko "paid + SG -> $cta_sg (want manage)"; fi
   if [ "$cta_us" = "manage" ]; then ok "paid + US storefront -> manage"; else ko "paid + US -> $cta_us (want manage)"; fi
+fi
+
+if [ "$tier" = "free" ]; then
+  echo "== 3b. restricted-storefront handoff must be refused (403) ==" >&2
+  refused=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$ZINC_ENDPOINT/api/v1.0/Auth/web-handoff" \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -d '{"platform": "ios", "storefront": "SG"}')
+  if [ "$refused" = "403" ]; then ok "free + SG handoff refused (403)"; else ko "free + SG handoff returned $refused (want 403)"; fi
 fi
 
 echo "== 4. own-account guard (CTA for another user must 403) ==" >&2


### PR DESCRIPTION
## What

Backend half of the neon→web seamless handoff (ClickUp [86ey5m5d1](https://app.clickup.com/t/86ey5m5d1)):

- **`POST /api/v1.0/Auth/web-handoff`** (authed) — resolves the caller's email from the JWT sub (never from input), mints a Logto one-time token via the lithium Management API (existing `Auth.Management` M2M credential), and returns a magic-link URL into the web billing portal: `{scheme}://{host}/auth/handoff?one_time_token=…&login_hint=…&redirect=…` (param names = Logto `signIn` extraParams, so the future argon landing page consumes them verbatim).
- **`GET /api/v1.0/Subscription/{userId}/cta?platform=&storefront=`** — which CTA the app may show: `manage` (paid, everywhere) / `subscribe` (free + allowlisted storefront) / `neutral` (everything else, fail-closed). Allowlists are per-landscape config (`WebPortal.Cta`), US + EU-27 by default, so steering-rule changes need no release.

## Security

- OTT: 300 s expiry (below Logto's 600 s default), single-use (verified live on pichu: `verify` → 200, second `verify` → 400 `token_consumed`).
- Mint only for the caller's own account; neutral-region mints refused server-side (403 `HandoffNotAvailable`).
- No email/token ever logged; URL built purely from server config (no open redirect).

## Tests

- `UnitTest/Handoff/` — CTA matrix (fail-closed cases incl. SG/null/garbage storefronts) + service (URL encoding incl. `+` emails, expiry passthrough, error propagation). 157/157 pass.
- `scripts/e2e/web-handoff.sh` — run against pichu post-deploy: proves the OTT is real + single-use via lithium `verify`, CTA matrix per storefront, cross-user 403, anonymous 401.

## Notes

- Based on `speedykrab/e2e-user-token` (includes its 2 commits — the e2e token script this depends on).
- Feasibility de-risked against lithium-pichu (Logto 1.32.0) before implementation; the `LogtoOneTimeTokenRes` DTO matches the live response shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpziHNSkVfCa3ygL5J196Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web portal subscription handoff flow, including a new authenticated endpoint that generates one-time login links.
  * Added a subscription CTA lookup endpoint so clients can fetch the correct CTA variant by platform and storefront.
  * Introduced new WebPortal configuration (scheme/host, handoff+redirect paths, magic-link expiry, and per-platform “Subscribe” country allowlists).

* **Bug Fixes**
  * Unsupported or disallowed storefront/platform requests now fail closed with a clear “handoff not available” response (403).  
  * Strengthened input validation for platform and storefront to prevent invalid handoff requests.

* **Tests**
  * Added unit tests for CTA steering rules and handoff URL/expiry behavior, plus a new end-to-end handoff script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->