### PR TITLE
fix: align subscription tier prices with launch pricing (pro $4.99, ultimate $7.99)

### DIFF
--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -243,14 +243,16 @@ Subscription:
       VacationWindowsYearly: 3
       FreezeBase: 7
     pro:
-      PriceCents: 500
+      # Launch price ($4.99) — must match the argon checkout display (alcohol.argon src/lib/billing/pricing.ts)
+      PriceCents: 499
       Currency: USD
       HabitsMax: 25
       SkipsMonthly: 20
       VacationWindowsYearly: 6
       FreezeBase: 14
     ultimate:
-      PriceCents: 1500
+      # Launch price ($7.99) — must match the argon checkout display
+      PriceCents: 799
       Currency: USD
       HabitsMax: 100
       SkipsMonthly: 60

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -243,14 +243,16 @@ Subscription:
       VacationWindowsYearly: 3
       FreezeBase: 7
     pro:
-      PriceCents: 500
+      # Launch price ($4.99) — must match the argon checkout display (alcohol.argon src/lib/billing/pricing.ts)
+      PriceCents: 499
       Currency: USD
       HabitsMax: 25
       SkipsMonthly: 20
       VacationWindowsYearly: 6
       FreezeBase: 14
     ultimate:
-      PriceCents: 1500
+      # Launch price ($7.99) — must match the argon checkout display
+      PriceCents: 799
       Currency: USD
       HabitsMax: 100
       SkipsMonthly: 60

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -243,14 +243,16 @@ Subscription:
       VacationWindowsYearly: 3
       FreezeBase: 7
     pro:
-      PriceCents: 500
+      # Launch price ($4.99) — must match the argon checkout display (alcohol.argon src/lib/billing/pricing.ts)
+      PriceCents: 499
       Currency: USD
       HabitsMax: 25
       SkipsMonthly: 20
       VacationWindowsYearly: 6
       FreezeBase: 14
     ultimate:
-      PriceCents: 1500
+      # Launch price ($7.99) — must match the argon checkout display
+      PriceCents: 799
       Currency: USD
       HabitsMax: 100
       SkipsMonthly: 60


### PR DESCRIPTION
## Why

The argon web checkout (AtomiCloud/alcohol.argon `speedykrab/billing-portal`) displays the marketing launch prices — pro **$4.99/mo**, ultimate **$7.99/mo**. zinc's `Subscription.Tiers[].PriceCents` is the charge source of truth (`SubscriptionPlanProvider` → `ChargeStoredConsentAsync`), so without this change users would be charged **$5.00/$15.00** against a **$4.99/$7.99** display.

## What

- `App/Config/settings.yaml`: pro `PriceCents` 500 → **499**, ultimate 1500 → **799**
- No landscape overrides exist, so this applies everywhere
- No tests reference tier prices

## Follow-up

Konnect catalog mirror (pro/ultimate plan flat-fee cards) updated separately per `docs/KONNECT_SETUP.md` §4 — Konnect is reporting-only, never enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TsgJ4AZ8U3vQniHR8wGtu