### PR TITLE
fix: give TierInsufficient a human-readable default detail

### DIFF
--- a/App/Error/V1/TierInsufficient.cs
+++ b/App/Error/V1/TierInsufficient.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json.Serialization;
+using App.StartUp.Registry;
+using Humanizer;
 using NJsonSchema.Annotations;
 
 namespace App.Error.V1;
@@ -7,11 +9,13 @@ namespace App.Error.V1;
 [Description("This error means your subscription tier does not allow this action.")]
 public class TierInsufficient : IDomainProblem
 {
+  private readonly string detail = string.Empty;
+
   public TierInsufficient() { }
 
   public TierInsufficient(string detail)
   {
-    this.Detail = detail;
+    this.detail = detail;
   }
 
   public TierInsufficient(string tier, string limitKey, int limitValue, string? detail = null)
@@ -19,7 +23,7 @@ public class TierInsufficient : IDomainProblem
     this.Tier = tier;
     this.LimitKey = limitKey;
     this.LimitValue = limitValue;
-    if (!string.IsNullOrWhiteSpace(detail)) this.Detail = detail!;
+    if (!string.IsNullOrWhiteSpace(detail)) this.detail = detail!;
   }
 
   [JsonIgnore, JsonSchemaIgnore]
@@ -31,8 +35,11 @@ public class TierInsufficient : IDomainProblem
   [JsonIgnore, JsonSchemaIgnore]
   public string Version { get; } = "v1";
 
+  // Never surface an empty detail: RFC7807 `detail` is what clients render, and an
+  // empty string is indistinguishable from "no message" to users. When no explicit
+  // detail is supplied, derive a human-readable one from Tier/LimitKey/LimitValue.
   [JsonIgnore, JsonSchemaIgnore]
-  public string Detail { get; } = string.Empty;
+  public string Detail => string.IsNullOrWhiteSpace(this.detail) ? this.DefaultDetail() : this.detail;
 
   [Description("The current subscription tier of the user")]
   public string Tier { get; } = string.Empty;
@@ -42,4 +49,26 @@ public class TierInsufficient : IDomainProblem
 
   [Description("The numeric limit value configured for the entitlement key")]
   public int LimitValue { get; } = 0;
+
+  private string DefaultDetail()
+  {
+    var plan = string.IsNullOrWhiteSpace(this.Tier) ? "current" : this.Tier;
+    var (noun, period) = this.LimitKey switch
+    {
+      EntitlementKeys.HabitsMax => ("habit", string.Empty),
+      EntitlementKeys.SkipsMonthly => ("skip", " per month"),
+      EntitlementKeys.VacationWindowsYearly => ("vacation window", " per year"),
+      EntitlementKeys.FreezeBase => ("streak freeze", string.Empty),
+      _ => ((string?)null, string.Empty),
+    };
+
+    if (noun == null)
+      return string.IsNullOrWhiteSpace(this.LimitKey)
+        ? $"Your {plan} plan does not allow this action."
+        : $"Your {plan} plan has reached its limit of {this.LimitValue} for '{this.LimitKey}'.";
+
+    return this.LimitValue <= 0
+      ? $"Your {plan} plan does not include {noun.Pluralize()}."
+      : $"Your {plan} plan allows up to {noun.ToQuantity(this.LimitValue)}{period}.";
+  }
 }

--- a/UnitTest/Error/TierInsufficientTests.cs
+++ b/UnitTest/Error/TierInsufficientTests.cs
@@ -1,0 +1,85 @@
+using App.Error.V1;
+using App.StartUp.Registry;
+
+namespace UnitTest.Error;
+
+// TierInsufficient is rendered to users via RFC7807 `detail` (see
+// ProblemDetailsService). An empty detail renders as an invisible message in the
+// clients, so when no explicit detail is supplied the error must derive a
+// human-readable one from its own Tier/LimitKey/LimitValue fields.
+public class TierInsufficientTests
+{
+  // ---------------------------------------------------------------------------
+  // Default detail — derived from tier + entitlement key + limit.
+  // ---------------------------------------------------------------------------
+  [Theory]
+  [InlineData("free", EntitlementKeys.HabitsMax, 2, "Your free plan allows up to 2 habits.")]
+  [InlineData("pro", EntitlementKeys.HabitsMax, 1, "Your pro plan allows up to 1 habit.")]
+  [InlineData("free", EntitlementKeys.SkipsMonthly, 10, "Your free plan allows up to 10 skips per month.")]
+  [InlineData("pro", EntitlementKeys.VacationWindowsYearly, 6, "Your pro plan allows up to 6 vacation windows per year.")]
+  [InlineData("pro", EntitlementKeys.FreezeBase, 14, "Your pro plan allows up to 14 streak freezes.")]
+  public void Detail_WithoutExplicitDetail_DerivesFromFields(
+    string tier, string limitKey, int limitValue, string expected)
+  {
+    var problem = new TierInsufficient(tier, limitKey, limitValue);
+
+    problem.Detail.Should().Be(expected);
+  }
+
+  // Zero-limit entitlements (e.g. free tier has no vacation windows) read as
+  // "does not include", not "allows up to 0".
+  [Theory]
+  [InlineData(EntitlementKeys.VacationWindowsYearly, "Your free plan does not include vacation windows.")]
+  [InlineData(EntitlementKeys.FreezeBase, "Your free plan does not include streak freezes.")]
+  public void Detail_ZeroLimit_ReadsAsNotIncluded(string limitKey, string expected)
+  {
+    var problem = new TierInsufficient("free", limitKey, 0);
+
+    problem.Detail.Should().Be(expected);
+  }
+
+  // Unknown keys and missing fields must still produce a sensible, non-empty
+  // message instead of leaking an empty detail.
+  [Fact]
+  public void Detail_UnknownLimitKey_FallsBackToGenericLimitMessage()
+  {
+    var problem = new TierInsufficient("free", "ent.something.new", 3);
+
+    problem.Detail.Should().Be("Your free plan has reached its limit of 3 for 'ent.something.new'.");
+  }
+
+  [Fact]
+  public void Detail_NoFieldsAtAll_IsStillNonEmpty()
+  {
+    var problem = new TierInsufficient();
+
+    problem.Detail.Should().Be("Your current plan does not allow this action.");
+  }
+
+  [Fact]
+  public void Detail_MissingTier_ReadsAsCurrentPlan()
+  {
+    var problem = new TierInsufficient(string.Empty, EntitlementKeys.HabitsMax, 2);
+
+    problem.Detail.Should().Be("Your current plan allows up to 2 habits.");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Explicit detail — always wins over the derived default.
+  // ---------------------------------------------------------------------------
+  [Fact]
+  public void Detail_ExplicitDetail_OverridesDefault()
+  {
+    var problem = new TierInsufficient("free", EntitlementKeys.HabitsMax, 2, "Custom message.");
+
+    problem.Detail.Should().Be("Custom message.");
+  }
+
+  [Fact]
+  public void Detail_DetailOnlyConstructor_IsPreserved()
+  {
+    var problem = new TierInsufficient("Custom message.");
+
+    problem.Detail.Should().Be("Custom message.");
+  }
+}


### PR DESCRIPTION
## Summary

`TierInsufficient` shipped `detail: ""` unless a caller supplied one — and no caller did — so clients rendered entitlement failures invisibly (pichu QA: the "silent 3rd habit" bug, ticket 86ey77mr6). The error now derives a default detail from its own fields, e.g. "Your free plan allows up to 2 habits." / "…10 skips per month." / "…6 vacation windows per year.", with a generic fallback for unknown keys. Explicit detail still wins; the RFC7807 `data` extension shape is unchanged, so existing clients only ever see `""` → text.

Pairs with AtomiCloud/alcohol.neon `speedykrab/fix-tier-error-display` (client-side empty-detail guard).

## Test plan

- `dotnet test UnitTest/` — 186 passed (12 new TierInsufficient tests covering all entitlement keys, pluralization, zero-limit wording, explicit-detail precedence)
- Reviewed independently; argon confirmed unaffected (renders `detail` as plain string, no empty-detail reliance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now show clearer, more helpful details when a plan limit is exceeded.
  * Messages automatically include the relevant plan name, limit, and period when no custom message is provided.
  * Zero-limit cases now read as “not included” instead of “allows up to 0,” making them easier to understand.
  * Custom error details continue to take priority when supplied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->