### PR TITLE
feat: NFC tag → habit mapping (NfcTag module)

### DIFF
--- a/App/Migrations/20260711063228_AddNfcTags.Designer.cs
+++ b/App/Migrations/20260711063228_AddNfcTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711063228_AddNfcTags")]
+    partial class AddNfcTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260711063228_AddNfcTags.cs
+++ b/App/Migrations/20260711063228_AddNfcTags.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNfcTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NfcTags",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ClaimedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    HabitId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NfcTags", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_NfcTags_Habits_HabitId",
+                        column: x => x.HabitId,
+                        principalTable: "Habits",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_NfcTags_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NfcTags_HabitId",
+                table: "NfcTags",
+                column: "HabitId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_NfcTags_UserId",
+                table: "NfcTags",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NfcTags");
+        }
+    }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -5,6 +5,8 @@ using App.Modules.Charities.Sync;
 using App.Modules.Configurations.Data;
 using App.Modules.Entitlement;
 using App.Modules.Habit.Data;
+using App.Modules.NfcTag;
+using App.Modules.NfcTag.Data;
 using App.Modules.Payment.Airwallex;
 using App.Modules.Payment.Data;
 using App.Modules.Penalty.Data;
@@ -24,6 +26,7 @@ using Domain.Configuration;
 using Domain.Disbursement;
 using Domain.Entitlement;
 using Domain.Habit;
+using Domain.NfcTag;
 using Domain.Payment;
 using Domain.Penalty;
 using Domain.Protection;
@@ -93,6 +96,12 @@ public static class DomainServices
       .AutoTrace<IVacationRepository>();
     s.AddScoped<IVacationService, VacationService>()
       .AutoTrace<IVacationService>();
+
+    // NFC tags
+    s.AddScoped<INfcTagRepository, NfcTagRepository>()
+      .AutoTrace<INfcTagRepository>();
+    s.AddScoped<INfcTagService, NfcTagService>()
+      .AutoTrace<INfcTagService>();
 
     // PENALTY
     s.AddScoped<IPenaltyService, PenaltyService>()

--- a/App/Modules/Habit/Data/HabitRepository.cs
+++ b/App/Modules/Habit/Data/HabitRepository.cs
@@ -387,6 +387,11 @@ namespace App.Modules.Habit.Data
                     return (Unit?)null;
                 }
 
+                // Habit deletion is a soft delete, so the NfcTags FK cascade never
+                // fires — release the physical tag here or its id stays claimed
+                // forever (409 for other users, 404 for the owner).
+                await db.NfcTags.Where(x => x.HabitId == habitId).ExecuteDeleteAsync();
+
                 logger.LogInformation("Soft deleted habit for HabitId: {HabitId}", habitId);
                 return new Unit();
             }

--- a/App/Modules/NfcTag/API/V1/NfcTagController.cs
+++ b/App/Modules/NfcTag/API/V1/NfcTagController.cs
@@ -1,0 +1,73 @@
+using System.Net.Mime;
+using System.Text.RegularExpressions;
+using App.Error.V1;
+using App.Modules.Common;
+using App.StartUp.Services.Auth;
+using App.Utility;
+using Asp.Versioning;
+using CSharp_Result;
+using Domain.NfcTag;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace App.Modules.NfcTag.API.V1;
+
+[ApiVersion(1.0)]
+[ApiController]
+[Consumes(MediaTypeNames.Application.Json)]
+[Route("api/v{version:apiVersion}/[controller]")]
+public partial class NfcTagController(
+  INfcTagService nfcTagService,
+  IAuthHelper authHelper,
+  LinkNfcTagReqValidator linkValidator
+) : AtomiControllerBase(authHelper)
+{
+  // Tag ids are client-generated (UUID-ish) strings embedded in the tag URL.
+  [GeneratedRegex("^[A-Za-z0-9-]{8,64}$")]
+  private static partial Regex TagIdRegex();
+
+  [Authorize, HttpPut("{userId}/{tagId}")]
+  public async Task<ActionResult<NfcTagRes>> Link(string userId, string tagId, [FromBody] LinkNfcTagReq req)
+  {
+    var result = await this.GuardAsync(userId)
+      .ThenAwait(_ => ValidateTagId(tagId))
+      .ThenAwait(_ => linkValidator.ValidateAsyncResult(req, "Invalid LinkNfcTagReq"))
+      .ThenAwait(r => nfcTagService.Link(userId, tagId, r.HabitId))
+      .Then(t => t.ToRes(), Errors.MapNone);
+
+    return this.ReturnResult(result);
+  }
+
+  [Authorize, HttpGet("{userId}/{tagId}")]
+  public async Task<ActionResult<NfcTagResolutionRes>> Resolve(string userId, string tagId)
+  {
+    var result = await this.GuardAsync(userId)
+      .ThenAwait(_ => ValidateTagId(tagId))
+      .ThenAwait(_ => nfcTagService.Resolve(userId, tagId))
+      .Then(r => r?.ToRes(), Errors.MapNone);
+
+    return this.ReturnNullableResult(result, new EntityNotFound("NFC Tag Not Found", typeof(NfcTagPrincipal), tagId));
+  }
+
+  [Authorize, HttpDelete("{userId}/{tagId}")]
+  public async Task<ActionResult> Unlink(string userId, string tagId)
+  {
+    var result = await this.GuardAsync(userId)
+      .ThenAwait(_ => ValidateTagId(tagId))
+      .ThenAwait(_ => nfcTagService.Unlink(userId, tagId));
+
+    return this.ReturnUnitNullableResult(result, new EntityNotFound("NFC Tag Not Found", typeof(NfcTagPrincipal), tagId));
+  }
+
+  private static Task<Result<Unit>> ValidateTagId(string tagId)
+  {
+    if (!TagIdRegex().IsMatch(tagId))
+    {
+      return Task.FromResult((Result<Unit>)new ValidationError(
+        "Invalid NFC tag id",
+        new Dictionary<string, string[]> { ["TagId"] = ["Tag id must be 8-64 characters of letters, digits or hyphens"] }
+      ).ToException());
+    }
+    return Task.FromResult((Result<Unit>)new Unit());
+  }
+}

--- a/App/Modules/NfcTag/API/V1/NfcTagMapper.cs
+++ b/App/Modules/NfcTag/API/V1/NfcTagMapper.cs
@@ -1,0 +1,24 @@
+using App.Modules.Habit.API.V1;
+using App.Utility;
+using Domain.NfcTag;
+
+namespace App.Modules.NfcTag.API.V1;
+
+public static class NfcTagMapper
+{
+  public static NfcTagRes ToRes(this NfcTagPrincipal t) =>
+    new(
+      t.Id,
+      t.UserId,
+      t.Record.HabitId,
+      t.ClaimedAt.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+    );
+
+  public static NfcTagResolutionRes ToRes(this NfcTagResolution r) =>
+    new(
+      r.Principal.ToRes(),
+      r.HabitVersion.ToRes(),
+      r.Today.ToStandardDateFormat(),
+      r.TodayExecution?.ToRes()
+    );
+}

--- a/App/Modules/NfcTag/API/V1/NfcTagModel.cs
+++ b/App/Modules/NfcTag/API/V1/NfcTagModel.cs
@@ -1,0 +1,21 @@
+using App.Modules.Habit.API.V1;
+
+namespace App.Modules.NfcTag.API.V1;
+
+public record LinkNfcTagReq(
+  Guid HabitId
+);
+
+public record NfcTagRes(
+  string Id,
+  string UserId,
+  Guid HabitId,
+  string ClaimedAt
+);
+
+public record NfcTagResolutionRes(
+  NfcTagRes Tag,
+  HabitVersionRes HabitVersion,     // current version — complete against this
+  string Today,                      // today in the habit's timezone
+  HabitExecutionRes? TodayExecution  // null = not yet acted on today
+);

--- a/App/Modules/NfcTag/API/V1/NfcTagValidator.cs
+++ b/App/Modules/NfcTag/API/V1/NfcTagValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace App.Modules.NfcTag.API.V1;
+
+public class LinkNfcTagReqValidator : AbstractValidator<LinkNfcTagReq>
+{
+  public LinkNfcTagReqValidator()
+  {
+    RuleFor(x => x.HabitId).NotEmpty();
+  }
+}

--- a/App/Modules/NfcTag/Data/NfcTagData.cs
+++ b/App/Modules/NfcTag/Data/NfcTagData.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using App.Modules.Habit.Data;
+using App.Modules.Users.Data;
+
+namespace App.Modules.NfcTag.Data;
+
+public class NfcTagData
+{
+  // Tag id embedded in the physical tag's URL (lazytax.club/t/{id}) — natural key.
+  [Key, MaxLength(64)]
+  public required string Id { get; set; }
+
+  public DateTime ClaimedAt { get; set; } = DateTime.UtcNow;
+
+  // Foreign Keys
+  [MaxLength(128)]
+  public required string UserId { get; set; }
+  public virtual UserData? User { get; set; }
+
+  public required Guid HabitId { get; set; }
+  public virtual HabitData? Habit { get; set; }
+}

--- a/App/Modules/NfcTag/Data/NfcTagMapper.cs
+++ b/App/Modules/NfcTag/Data/NfcTagMapper.cs
@@ -1,0 +1,17 @@
+using Domain.NfcTag;
+
+namespace App.Modules.NfcTag.Data;
+
+public static class NfcTagMapper
+{
+  public static NfcTagPrincipal ToPrincipal(this NfcTagData data)
+  {
+    return new NfcTagPrincipal
+    {
+      Id = data.Id,
+      UserId = data.UserId,
+      ClaimedAt = data.ClaimedAt,
+      Record = new NfcTagRecord { HabitId = data.HabitId }
+    };
+  }
+}

--- a/App/Modules/NfcTag/Data/NfcTagMapper.cs
+++ b/App/Modules/NfcTag/Data/NfcTagMapper.cs
@@ -4,6 +4,11 @@ namespace App.Modules.NfcTag.Data;
 
 public static class NfcTagMapper
 {
+  public static NfcTagRecord ToRecord(this NfcTagData data)
+  {
+    return new NfcTagRecord { HabitId = data.HabitId };
+  }
+
   public static NfcTagPrincipal ToPrincipal(this NfcTagData data)
   {
     return new NfcTagPrincipal
@@ -11,7 +16,17 @@ public static class NfcTagMapper
       Id = data.Id,
       UserId = data.UserId,
       ClaimedAt = data.ClaimedAt,
-      Record = new NfcTagRecord { HabitId = data.HabitId }
+      Record = data.ToRecord()
     };
+  }
+
+  // No ToDomain: NfcTag has no aggregate model (Principal is the full shape).
+  // No ToData(record): the natural key (tag id) and owner are not part of the
+  // Record, so a data row cannot be built from a Record alone.
+
+  public static NfcTagData ToData(this NfcTagData data, NfcTagRecord record)
+  {
+    data.HabitId = record.HabitId;
+    return data;
   }
 }

--- a/App/Modules/NfcTag/Data/NfcTagRepository.cs
+++ b/App/Modules/NfcTag/Data/NfcTagRepository.cs
@@ -1,0 +1,96 @@
+using App.Error.V1;
+using App.Modules.HabitExecution.Data;
+using App.StartUp.Database;
+using App.Utility;
+using CSharp_Result;
+using Domain.Habit;
+using Domain.NfcTag;
+using EntityFramework.Exceptions.Common;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.NfcTag.Data;
+
+public class NfcTagRepository(MainDbContext db, ILogger<NfcTagRepository> logger) : INfcTagRepository
+{
+  public async Task<Result<NfcTagPrincipal?>> Get(string tagId)
+  {
+    try
+    {
+      var data = await db.NfcTags.AsNoTracking().Where(x => x.Id == tagId).FirstOrDefaultAsync();
+      return data?.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Get NFC tag failed for Id={Id}", tagId);
+      throw;
+    }
+  }
+
+  public async Task<Result<NfcTagPrincipal>> Upsert(string tagId, string userId, Guid habitId)
+  {
+    try
+    {
+      var data = await db.NfcTags.Where(x => x.Id == tagId).FirstOrDefaultAsync();
+      if (data == null)
+      {
+        logger.LogInformation("Claiming NFC tag Id={Id} for UserId={UserId} HabitId={HabitId}", tagId, userId, habitId);
+        data = new NfcTagData { Id = tagId, UserId = userId, HabitId = habitId };
+        db.NfcTags.Add(data);
+      }
+      else
+      {
+        logger.LogInformation("Re-linking NFC tag Id={Id} for UserId={UserId} to HabitId={HabitId}", tagId, userId, habitId);
+        data.HabitId = habitId;
+      }
+
+      await db.SaveChangesAsync();
+      return data.ToPrincipal();
+    }
+    catch (UniqueConstraintException e)
+    {
+      // Two users raced to claim the same unclaimed tag — first insert wins.
+      logger.LogError(e, "NFC tag claim conflict for Id={Id} UserId={UserId}", tagId, userId);
+      return new EntityConflict("NFC tag is already linked by another user", typeof(NfcTagPrincipal))
+        .ToException();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Upsert NFC tag failed for Id={Id} UserId={UserId}", tagId, userId);
+      throw;
+    }
+  }
+
+  public async Task<Result<Unit?>> Delete(string tagId, string userId)
+  {
+    try
+    {
+      var affected = await db.NfcTags
+        .Where(x => x.Id == tagId && x.UserId == userId)
+        .ExecuteDeleteAsync();
+      if (affected == 0) return (Unit?)null;
+      return new Unit();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Delete NFC tag failed for Id={Id}", tagId);
+      throw;
+    }
+  }
+
+  public async Task<Result<HabitExecutionPrincipal?>> GetExecutionForDate(Guid habitId, DateOnly date)
+  {
+    try
+    {
+      var data = await db.HabitExecutions.AsNoTracking()
+        .Where(x => x.Date == date && x.HabitVersion!.HabitId == habitId)
+        .OrderByDescending(x => x.CompletedAt)
+        .FirstOrDefaultAsync();
+      return data?.ToPrincipal();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "GetExecutionForDate failed for HabitId={HabitId} Date={Date}", habitId, date);
+      throw;
+    }
+  }
+}

--- a/App/Modules/NfcTag/Data/NfcTagRepository.cs
+++ b/App/Modules/NfcTag/Data/NfcTagRepository.cs
@@ -37,10 +37,19 @@ public class NfcTagRepository(MainDbContext db, ILogger<NfcTagRepository> logger
         data = new NfcTagData { Id = tagId, UserId = userId, HabitId = habitId };
         db.NfcTags.Add(data);
       }
+      else if (data.UserId != userId)
+      {
+        // Ownership re-checked here, not just in the service: the service's
+        // check reads a snapshot, so a competing claim committed between that
+        // read and this one would otherwise be silently re-pointed.
+        logger.LogWarning("NFC tag claim conflict for Id={Id}: owned by another user", tagId);
+        return new EntityConflict("NFC tag is already linked by another user", typeof(NfcTagPrincipal))
+          .ToException();
+      }
       else
       {
         logger.LogInformation("Re-linking NFC tag Id={Id} for UserId={UserId} to HabitId={HabitId}", tagId, userId, habitId);
-        data.HabitId = habitId;
+        data.ToData(new NfcTagRecord { HabitId = habitId });
       }
 
       await db.SaveChangesAsync();
@@ -81,9 +90,11 @@ public class NfcTagRepository(MainDbContext db, ILogger<NfcTagRepository> logger
   {
     try
     {
+      // Postgres sorts NULLS FIRST on DESC, so coalesce: a completed row must
+      // win over same-day failure/vacation rows (which have no CompletedAt).
       var data = await db.HabitExecutions.AsNoTracking()
         .Where(x => x.Date == date && x.HabitVersion!.HabitId == habitId)
-        .OrderByDescending(x => x.CompletedAt)
+        .OrderByDescending(x => x.CompletedAt ?? DateTime.MinValue)
         .FirstOrDefaultAsync();
       return data?.ToPrincipal();
     }

--- a/App/Modules/NfcTag/NfcTagService.cs
+++ b/App/Modules/NfcTag/NfcTagService.cs
@@ -1,0 +1,69 @@
+using App.Error.V1;
+using App.Utility;
+using CSharp_Result;
+using Domain.Exceptions;
+using Domain.Habit;
+using Domain.NfcTag;
+
+namespace App.Modules.NfcTag;
+
+public class NfcTagService(
+  INfcTagRepository repo,
+  IHabitService habitService
+) : INfcTagService
+{
+  public Task<Result<NfcTagPrincipal>> Link(string userId, string tagId, Guid habitId)
+  {
+    return habitService.GetCurrentHabitVersion(userId, habitId)
+      .ThenAwait(async hv =>
+      {
+        if (hv == null)
+          return (Result<NfcTagPrincipal>)new NotFoundException("Habit Not Found", typeof(HabitPrincipal), habitId.ToString());
+
+        return await repo.Get(tagId)
+          .ThenAwait<NfcTagPrincipal?, NfcTagPrincipal>(async existing =>
+          {
+            if (existing != null && existing.UserId != userId)
+              return new EntityConflict("NFC tag is already linked by another user", typeof(NfcTagPrincipal))
+                .ToException();
+
+            return await repo.Upsert(tagId, userId, habitId);
+          });
+      });
+  }
+
+  public Task<Result<NfcTagResolution?>> Resolve(string userId, string tagId)
+  {
+    return repo.Get(tagId)
+      .ThenAwait(async tag =>
+      {
+        // Unclaimed and foreign-owned look identical to the caller (404):
+        // resolving must never leak who owns a tag.
+        if (tag == null || tag.UserId != userId)
+          return (Result<NfcTagResolution?>)(NfcTagResolution?)null;
+
+        return await habitService.GetCurrentHabitVersion(userId, tag.Record.HabitId)
+          .ThenAwait<HabitVersionPrincipal?, NfcTagResolution?>(async hv =>
+          {
+            if (hv == null) return (NfcTagResolution?)null;
+
+            var tz = TimeZoneInfo.FindSystemTimeZoneById(hv.Record.Timezone);
+            var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));
+
+            return await repo.GetExecutionForDate(tag.Record.HabitId, today)
+              .Then(exec => (NfcTagResolution?)new NfcTagResolution
+              {
+                Principal = tag,
+                HabitVersion = hv,
+                Today = today,
+                TodayExecution = exec
+              }, Errors.MapNone);
+          });
+      });
+  }
+
+  public Task<Result<Unit?>> Unlink(string userId, string tagId)
+  {
+    return repo.Delete(tagId, userId);
+  }
+}

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -5,6 +5,7 @@ using App.Modules.Disbursement.Data;
 using App.Modules.Habit.Data;
 using App.Modules.HabitExecution.Data;
 using App.Modules.HabitVersion.Data;
+using App.Modules.NfcTag.Data;
 using App.Modules.Payment.Data;
 using App.Modules.Penalty.Data;
 using App.Modules.Protection.Data;
@@ -48,6 +49,8 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
   public DbSet<DisbursementData> Disbursements { get; set; }
   // Subscription (paid tiers)
   public DbSet<UserSubscriptionData> UserSubscriptions { get; set; }
+  // NFC tags (physical tag → habit mapping)
+  public DbSet<NfcTagData> NfcTags { get; set; }
   // public DbSet<CompletionData> Completions { get; set; }
   // public DbSet<StatsData> Stats { get; set; }
 
@@ -132,6 +135,19 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
                   .WithMany(x => x.Consents)
                   .HasForeignKey(x => x.PaymentCustomerId)
                   .OnDelete(DeleteBehavior.Cascade);
+
+    // NFC tags: natural key = tag id from the physical tag's URL. Cascade on
+    // habit delete releases the tag back to unclaimed (re-linkable).
+    var nfcTag = modelBuilder.Entity<NfcTagData>();
+    nfcTag.HasIndex(x => x.UserId);
+    nfcTag.HasOne(x => x.User)
+          .WithMany()
+          .HasForeignKey(x => x.UserId)
+          .OnDelete(DeleteBehavior.Cascade);
+    nfcTag.HasOne(x => x.Habit)
+          .WithMany()
+          .HasForeignKey(x => x.HabitId)
+          .OnDelete(DeleteBehavior.Cascade);
 
     // VacationPeriods
     var vacation = modelBuilder.Entity<VacationPeriodData>();

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -136,8 +136,9 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
                   .HasForeignKey(x => x.PaymentCustomerId)
                   .OnDelete(DeleteBehavior.Cascade);
 
-    // NFC tags: natural key = tag id from the physical tag's URL. Cascade on
-    // habit delete releases the tag back to unclaimed (re-linkable).
+    // NFC tags: natural key = tag id from the physical tag's URL. The cascades
+    // cover hard deletes (user purge); habit deletion is a soft delete, so
+    // HabitRepository.Delete releases tags explicitly.
     var nfcTag = modelBuilder.Entity<NfcTagData>();
     nfcTag.HasIndex(x => x.UserId);
     nfcTag.HasOne(x => x.User)

--- a/Domain/NfcTag/IService.cs
+++ b/Domain/NfcTag/IService.cs
@@ -1,0 +1,22 @@
+using CSharp_Result;
+
+namespace Domain.NfcTag;
+
+public interface INfcTagService
+{
+  /// <summary>
+  /// Create-or-replace the tag → habit mapping. Creates the mapping when the
+  /// tag is unclaimed, updates it when the caller already owns it, and fails
+  /// with EntityConflict when another user owns it (first-come-first-served).
+  /// </summary>
+  Task<Result<NfcTagPrincipal>> Link(string userId, string tagId, Guid habitId);
+
+  /// <summary>
+  /// Resolve a tag to its habit's current version and today's execution
+  /// status. Returns null (not found) when the tag is unclaimed or owned by
+  /// another user — ownership is never leaked.
+  /// </summary>
+  Task<Result<NfcTagResolution?>> Resolve(string userId, string tagId);
+
+  Task<Result<Unit?>> Unlink(string userId, string tagId);
+}

--- a/Domain/NfcTag/Model.cs
+++ b/Domain/NfcTag/Model.cs
@@ -1,0 +1,27 @@
+using Domain.Habit;
+
+namespace Domain.NfcTag;
+
+public record NfcTagRecord
+{
+  public required Guid HabitId { get; init; }
+}
+
+public record NfcTagPrincipal
+{
+  public required string Id { get; init; }  // tag id embedded in the physical tag's URL
+  public required string UserId { get; init; }
+  public required DateTime ClaimedAt { get; init; }
+  public required NfcTagRecord Record { get; init; }
+}
+
+// Resolve aggregate: everything the client needs to act on a tap without
+// storing version ids on the tag — the mapping, the habit's current version,
+// and whether the habit was already acted on today (in the habit's timezone).
+public record NfcTagResolution
+{
+  public required NfcTagPrincipal Principal { get; init; }
+  public required HabitVersionPrincipal HabitVersion { get; init; }
+  public required DateOnly Today { get; init; }
+  public HabitExecutionPrincipal? TodayExecution { get; init; }
+}

--- a/Domain/NfcTag/Repository.cs
+++ b/Domain/NfcTag/Repository.cs
@@ -1,0 +1,17 @@
+using CSharp_Result;
+using Domain.Habit;
+
+namespace Domain.NfcTag;
+
+public interface INfcTagRepository
+{
+  Task<Result<NfcTagPrincipal?>> Get(string tagId);
+  Task<Result<NfcTagPrincipal>> Upsert(string tagId, string userId, Guid habitId);
+  Task<Result<Unit?>> Delete(string tagId, string userId);
+
+  /// <summary>
+  /// Latest execution of any version of the habit on the given date, or null
+  /// when the habit has not been acted on that day.
+  /// </summary>
+  Task<Result<HabitExecutionPrincipal?>> GetExecutionForDate(Guid habitId, DateOnly date);
+}

--- a/IntTest/NfcTag/NfcTagIntegrationTests.cs
+++ b/IntTest/NfcTag/NfcTagIntegrationTests.cs
@@ -1,0 +1,228 @@
+using App.Error;
+using App.Error.V1;
+using App.Modules.Charities.Data;
+using App.Modules.Habit.Data;
+using App.Modules.HabitExecution.Data;
+using App.Modules.HabitVersion.Data;
+using App.Modules.NfcTag.Data;
+using App.Modules.Users.Data;
+using App.StartUp.Database;
+using App.StartUp.Options;
+using CSharp_Result;
+using Domain.Habit;
+using IntTest.Penalty;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace IntTest.NfcTag;
+
+// DB-backed integration tests for the NfcTag mapping against a REAL Postgres
+// MainDbContext: claim / remap / cross-user conflict on the repository's own
+// read-modify-write path, execution ordering across versions (Postgres NULLS
+// FIRST on DESC), owner-only delete, and the habit soft-delete releasing tags.
+//
+// Connection comes from the NFC_TAG_TEST_DB env var (same format as
+// PENALTY_TEST_DB, e.g. "Host=localhost;Port=5432;Database=nfc_test;
+// Username=postgres;Password=postgres;"). Unset -> tests Skip, so the suite
+// stays green without a database.
+[Collection(DbIntegrationCollection.Name)]
+public class NfcTagIntegrationTests : IAsyncLifetime
+{
+  private const string SkipReason = "NFC_TAG_TEST_DB not set; skipping DB-backed NFC tag integration test.";
+  private readonly string? _conn = Environment.GetEnvironmentVariable("NFC_TAG_TEST_DB");
+  private MainDbContext _db = null!;
+
+  public async Task InitializeAsync()
+  {
+    if (_conn == null) return;
+    _db = NewContext(_conn);
+    await _db.Database.EnsureCreatedAsync();
+  }
+
+  public async Task DisposeAsync()
+  {
+    if (_conn == null) return;
+    await _db.Database.EnsureDeletedAsync();
+    await _db.DisposeAsync();
+  }
+
+  private static MainDbContext NewContext(string conn)
+  {
+    var parts = conn.Split(';', StringSplitOptions.RemoveEmptyEntries)
+      .Select(p => p.Split('=', 2))
+      .Where(kv => kv.Length == 2)
+      .ToDictionary(kv => kv[0].Trim().ToLowerInvariant(), kv => kv[1].Trim());
+
+    var opt = new DatabaseOption
+    {
+      Host = parts.GetValueOrDefault("host", "localhost"),
+      Port = int.TryParse(parts.GetValueOrDefault("port", "5432"), out var p) ? p : 5432,
+      Database = parts.GetValueOrDefault("database", "nfc_test"),
+      User = parts.GetValueOrDefault("username", parts.GetValueOrDefault("user", "postgres")),
+      Password = parts.GetValueOrDefault("password", "postgres"),
+      AutoMigrate = false,
+      Timeout = 30
+    };
+    var monitor = new StaticOptionsMonitor<Dictionary<string, DatabaseOption>>(
+      new Dictionary<string, DatabaseOption> { [MainDbContext.Key] = opt });
+    return new MainDbContext(monitor, NullLoggerFactory.Instance);
+  }
+
+  private NfcTagRepository Repo() => new(_db, NullLogger<NfcTagRepository>.Instance);
+
+  private async Task<string> SeedUser()
+  {
+    var userId = $"user-{Guid.NewGuid():N}";
+    _db.Users.Add(new UserData { Id = userId, Username = userId, Email = $"{userId}@test.local" });
+    await _db.SaveChangesAsync();
+    return userId;
+  }
+
+  private async Task<(Guid HabitId, Guid VersionId)> SeedHabit(string userId)
+  {
+    var habitId = Guid.NewGuid();
+    var versionId = Guid.NewGuid();
+    var charityId = Guid.NewGuid();
+    _db.Charities.Add(new CharityData { Id = charityId, Name = $"Charity {charityId:N}" });
+    _db.Habits.Add(new HabitData { Id = habitId, UserId = userId, Version = 1, Enabled = true });
+    _db.HabitVersions.Add(new HabitVersionData
+    {
+      Id = versionId,
+      HabitId = habitId,
+      CharityId = charityId,
+      Version = 1,
+      Task = $"task-{versionId:N}",
+      DaysOfWeek = ["Monday"],
+      Timezone = "Asia/Singapore"
+    });
+    await _db.SaveChangesAsync();
+    return (habitId, versionId);
+  }
+
+  private static string NewTagId() => Guid.NewGuid().ToString();
+
+  [SkippableFact]
+  public async Task Upsert_ClaimRemapAndCrossUserConflict()
+  {
+    Skip.If(_conn == null, SkipReason);
+    var repo = Repo();
+    var owner = await SeedUser();
+    var stranger = await SeedUser();
+    var (habitA, _) = await SeedHabit(owner);
+    var (habitB, _) = await SeedHabit(owner);
+    var (habitS, _) = await SeedHabit(stranger);
+    var tagId = NewTagId();
+
+    // Claim
+    var claimed = await repo.Upsert(tagId, owner, habitA);
+    claimed.IsSuccess().Should().BeTrue();
+
+    // Remap (same owner) keeps one row, updates the habit
+    var remapped = await repo.Upsert(tagId, owner, habitB);
+    remapped.IsSuccess().Should().BeTrue();
+    var row = await _db.NfcTags.AsNoTracking().SingleAsync(x => x.Id == tagId);
+    row.HabitId.Should().Be(habitB);
+    row.UserId.Should().Be(owner);
+
+    // Cross-user upsert hits the repository's own ownership guard (the
+    // service-level check is bypassed here on purpose - defense in depth)
+    var hijack = await repo.Upsert(tagId, stranger, habitS);
+    var error = hijack.FailureOrDefault();
+    error.Should().BeOfType<DomainProblemException>();
+    ((DomainProblemException)error).Problem.Should().BeOfType<EntityConflict>();
+    (await _db.NfcTags.AsNoTracking().SingleAsync(x => x.Id == tagId))
+      .UserId.Should().Be(owner, "the original owner keeps the tag");
+  }
+
+  [SkippableFact]
+  public async Task GetExecutionForDate_CompletionWinsOverNullCompletedAt_AcrossVersions()
+  {
+    Skip.If(_conn == null, SkipReason);
+    var repo = Repo();
+    var owner = await SeedUser();
+    var (habitId, v1) = await SeedHabit(owner);
+
+    // Second version of the SAME habit (edit): unique(version, habit) per schema
+    var v2 = Guid.NewGuid();
+    var charityId = Guid.NewGuid();
+    _db.Charities.Add(new CharityData { Id = charityId, Name = $"Charity {charityId:N}" });
+    _db.HabitVersions.Add(new HabitVersionData
+    {
+      Id = v2,
+      HabitId = habitId,
+      CharityId = charityId,
+      Version = 2,
+      Task = "task-v2",
+      DaysOfWeek = ["Monday"],
+      Timezone = "Asia/Singapore"
+    });
+
+    var today = DateOnly.FromDateTime(DateTime.UtcNow);
+    // v1: a Vacation row with NULL CompletedAt; v2: a real completion.
+    // Postgres sorts NULLS FIRST on DESC - the coalesced ordering must still
+    // surface the completion.
+    _db.HabitExecutions.Add(new HabitExecutionData
+    {
+      Id = Guid.NewGuid(),
+      HabitVersionId = v1,
+      Date = today,
+      Status = HabitExecutionStatusData.Vacation
+    });
+    _db.HabitExecutions.Add(new HabitExecutionData
+    {
+      Id = Guid.NewGuid(),
+      HabitVersionId = v2,
+      Date = today,
+      Status = HabitExecutionStatusData.Completed,
+      CompletedAt = DateTime.UtcNow
+    });
+    await _db.SaveChangesAsync();
+
+    var result = await repo.GetExecutionForDate(habitId, today);
+
+    result.IsSuccess().Should().BeTrue();
+    var execution = (HabitExecutionPrincipal?)result;
+    execution.Should().NotBeNull();
+    execution!.Record.Status.Should().Be(ExecutionStatus.Completed);
+  }
+
+  [SkippableFact]
+  public async Task Delete_IsOwnerOnly()
+  {
+    Skip.If(_conn == null, SkipReason);
+    var repo = Repo();
+    var owner = await SeedUser();
+    var stranger = await SeedUser();
+    var (habitId, _) = await SeedHabit(owner);
+    var tagId = NewTagId();
+    (await repo.Upsert(tagId, owner, habitId)).IsSuccess().Should().BeTrue();
+
+    var strangerDelete = await repo.Delete(tagId, stranger);
+    ((Unit?)strangerDelete).Should().BeNull("someone else's unlink must not delete");
+    (await _db.NfcTags.AsNoTracking().CountAsync(x => x.Id == tagId)).Should().Be(1);
+
+    var ownerDelete = await repo.Delete(tagId, owner);
+    ((Unit?)ownerDelete).Should().NotBeNull();
+    (await _db.NfcTags.AsNoTracking().CountAsync(x => x.Id == tagId)).Should().Be(0);
+  }
+
+  [SkippableFact]
+  public async Task HabitSoftDelete_ReleasesTheTag()
+  {
+    Skip.If(_conn == null, SkipReason);
+    var nfcRepo = Repo();
+    var habitRepo = new HabitRepository(_db, NullLogger<HabitRepository>.Instance);
+    var owner = await SeedUser();
+    var (habitId, _) = await SeedHabit(owner);
+    var tagId = NewTagId();
+    (await nfcRepo.Upsert(tagId, owner, habitId)).IsSuccess().Should().BeTrue();
+
+    var deleted = await habitRepo.Delete(habitId, owner);
+
+    ((Unit?)deleted).Should().NotBeNull();
+    (await _db.Habits.AsNoTracking().SingleAsync(x => x.Id == habitId))
+      .DeletedAt.Should().NotBeNull("habit deletion is a soft delete");
+    (await _db.NfcTags.AsNoTracking().AnyAsync(x => x.Id == tagId))
+      .Should().BeFalse("the tag must be released so the sticker is reusable");
+  }
+}

--- a/UnitTest/NfcTag/Fakes.cs
+++ b/UnitTest/NfcTag/Fakes.cs
@@ -1,3 +1,5 @@
+using App.Error.V1;
+using App.Utility;
 using CSharp_Result;
 using Domain.Habit;
 using Domain.NfcTag;
@@ -20,12 +22,19 @@ public sealed class FakeNfcTagRepository : INfcTagRepository
 
   public Task<Result<NfcTagPrincipal>> Upsert(string tagId, string userId, Guid habitId)
   {
-    var claimedAt = Tags.TryGetValue(tagId, out var existing) ? existing.ClaimedAt : DateTime.UtcNow;
+    // Mirrors the real repository: the update path never re-points a tag
+    // owned by someone else (defense-in-depth against the claim race).
+    if (Tags.TryGetValue(tagId, out var existing) && existing.UserId != userId)
+    {
+      return Task.FromResult<Result<NfcTagPrincipal>>(
+        new EntityConflict("NFC tag is already linked by another user", typeof(NfcTagPrincipal)).ToException());
+    }
+
     var tag = new NfcTagPrincipal
     {
       Id = tagId,
       UserId = userId,
-      ClaimedAt = claimedAt,
+      ClaimedAt = existing?.ClaimedAt ?? DateTime.UtcNow,
       Record = new NfcTagRecord { HabitId = habitId }
     };
     Tags[tagId] = tag;

--- a/UnitTest/NfcTag/Fakes.cs
+++ b/UnitTest/NfcTag/Fakes.cs
@@ -1,0 +1,88 @@
+using CSharp_Result;
+using Domain.Habit;
+using Domain.NfcTag;
+
+namespace UnitTest.NfcTag;
+
+// Hand-rolled fakes implementing the real contracts (no Moq, matching the
+// UnitTest/Handoff style) for the NfcTagService tests.
+
+public sealed class FakeNfcTagRepository : INfcTagRepository
+{
+  public Dictionary<string, NfcTagPrincipal> Tags { get; } = [];
+  public Dictionary<(Guid HabitId, DateOnly Date), HabitExecutionPrincipal> Executions { get; } = [];
+
+  public Task<Result<NfcTagPrincipal?>> Get(string tagId)
+  {
+    Tags.TryGetValue(tagId, out var tag);
+    return Task.FromResult<Result<NfcTagPrincipal?>>(tag);
+  }
+
+  public Task<Result<NfcTagPrincipal>> Upsert(string tagId, string userId, Guid habitId)
+  {
+    var claimedAt = Tags.TryGetValue(tagId, out var existing) ? existing.ClaimedAt : DateTime.UtcNow;
+    var tag = new NfcTagPrincipal
+    {
+      Id = tagId,
+      UserId = userId,
+      ClaimedAt = claimedAt,
+      Record = new NfcTagRecord { HabitId = habitId }
+    };
+    Tags[tagId] = tag;
+    return Task.FromResult<Result<NfcTagPrincipal>>(tag);
+  }
+
+  public Task<Result<Unit?>> Delete(string tagId, string userId)
+  {
+    if (Tags.TryGetValue(tagId, out var tag) && tag.UserId == userId)
+    {
+      Tags.Remove(tagId);
+      return Task.FromResult<Result<Unit?>>(new Unit());
+    }
+    return Task.FromResult<Result<Unit?>>((Unit?)null);
+  }
+
+  public Task<Result<HabitExecutionPrincipal?>> GetExecutionForDate(Guid habitId, DateOnly date)
+  {
+    Executions.TryGetValue((habitId, date), out var exec);
+    return Task.FromResult<Result<HabitExecutionPrincipal?>>(exec);
+  }
+}
+
+public sealed class FakeHabitService : IHabitService
+{
+  // (userId, habitId) → current version; unknown pairs resolve to null.
+  public Dictionary<(string UserId, Guid HabitId), HabitVersionPrincipal> Versions { get; } = [];
+
+  public Task<Result<HabitVersionPrincipal?>> GetCurrentHabitVersion(string userId, Guid habitId)
+  {
+    Versions.TryGetValue((userId, habitId), out var hv);
+    return Task.FromResult<Result<HabitVersionPrincipal?>>(hv);
+  }
+
+  public Task<Result<List<HabitVersionPrincipal>>> SearchHabits(HabitSearch habitSearch) =>
+    throw new NotImplementedException();
+
+  public Task<Result<HabitVersionPrincipal>> Create(string userId, HabitVersionRecord versionRecord) =>
+    throw new NotImplementedException();
+
+  public Task<Result<HabitVersionPrincipal?>> Update(string userId, Guid habitId, HabitVersionRecord versionRecord, bool enabled) =>
+    throw new NotImplementedException();
+
+  public Task<Result<Unit?>> Delete(Guid habitId, string userId) => throw new NotImplementedException();
+
+  public Task<Result<int>> MarkDailyFailures(List<Guid> habitIds, DateOnly date) =>
+    throw new NotImplementedException();
+
+  public Task<Result<int>> MarkDailyFailuresForTimezonesNearMidnight(DateTime? nowUtc = null) =>
+    throw new NotImplementedException();
+
+  public Task<Result<HabitExecutionPrincipal>> CompleteHabit(string userId, Guid habitId, string? notes) =>
+    throw new NotImplementedException();
+
+  public Task<Result<HabitExecutionPrincipal>> SkipHabit(string userId, Guid habitVersionId, string? notes) =>
+    throw new NotImplementedException();
+
+  public Task<Result<List<HabitExecutionPrincipal>>> SearchHabitExecutions(string userId, HabitExecutionSearch habitExecutionSearch) =>
+    throw new NotImplementedException();
+}

--- a/UnitTest/NfcTag/NfcTagServiceTests.cs
+++ b/UnitTest/NfcTag/NfcTagServiceTests.cs
@@ -136,9 +136,24 @@ public class NfcTagServiceTests
 
     var result = await svc.Resolve(Owner, TagId);
 
+    result.IsSuccess().Should().BeTrue();
     var resolution = (NfcTagResolution?)result;
     resolution.Should().NotBeNull();
     resolution!.TodayExecution.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Resolve_HabitDeletedAfterLinking_ReturnsNull()
+  {
+    var (svc, _, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    await svc.Link(Owner, TagId, HabitA);
+    habits.Versions.Remove((Owner, HabitA));
+
+    var result = await svc.Resolve(Owner, TagId);
+
+    result.IsSuccess().Should().BeTrue();
+    ((NfcTagResolution?)result).Should().BeNull("a dangling tag must resolve like an unclaimed one");
   }
 
   [Fact]

--- a/UnitTest/NfcTag/NfcTagServiceTests.cs
+++ b/UnitTest/NfcTag/NfcTagServiceTests.cs
@@ -1,0 +1,195 @@
+using App.Error;
+using App.Error.V1;
+using App.Modules.NfcTag;
+using App.Utility;
+using Domain.Exceptions;
+using Domain.Habit;
+using Domain.NfcTag;
+using NodaMoney;
+
+namespace UnitTest.NfcTag;
+
+// NfcTagService: link (claim / re-link / FCFS conflict / unknown habit),
+// resolve (owner-only, no ownership leak, today's execution), and unlink.
+public class NfcTagServiceTests
+{
+  private const string Owner = "user-1";
+  private const string Stranger = "user-2";
+  private const string TagId = "3f9c2b7e-1a2b-4c3d-8e9f-0a1b2c3d4e5f";
+
+  private static readonly Guid HabitA = Guid.NewGuid();
+  private static readonly Guid HabitB = Guid.NewGuid();
+
+  private static HabitVersionPrincipal Version(Guid habitId, string timezone = "Asia/Singapore") => new()
+  {
+    Id = Guid.NewGuid(),
+    HabitId = habitId,
+    Version = 1,
+    Record = new HabitVersionRecord
+    {
+      CharityId = Guid.NewGuid(),
+      Task = "Eat medicine",
+      DaysOfWeek = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
+      NotificationTime = new TimeOnly(21, 0),
+      Stake = new Money(5m, Currency.FromCode("USD")),
+      Ratio = 1.0m,
+      Timezone = timezone
+    }
+  };
+
+  private static (NfcTagService Svc, FakeNfcTagRepository Repo, FakeHabitService Habits) Make()
+  {
+    var repo = new FakeNfcTagRepository();
+    var habits = new FakeHabitService();
+    return (new NfcTagService(repo, habits), repo, habits);
+  }
+
+  [Fact]
+  public async Task Link_UnclaimedTag_CreatesMapping()
+  {
+    var (svc, repo, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+
+    var result = await svc.Link(Owner, TagId, HabitA);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.Tags[TagId].UserId.Should().Be(Owner);
+    repo.Tags[TagId].Record.HabitId.Should().Be(HabitA);
+  }
+
+  [Fact]
+  public async Task Link_OwnTag_RemapsToNewHabit()
+  {
+    var (svc, repo, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    habits.Versions[(Owner, HabitB)] = Version(HabitB);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Link(Owner, TagId, HabitB);
+
+    result.IsSuccess().Should().BeTrue();
+    repo.Tags[TagId].Record.HabitId.Should().Be(HabitB);
+    repo.Tags.Should().HaveCount(1);
+  }
+
+  [Fact]
+  public async Task Link_TagOwnedByAnotherUser_FailsWithEntityConflict()
+  {
+    var (svc, repo, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    habits.Versions[(Stranger, HabitB)] = Version(HabitB);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Link(Stranger, TagId, HabitB);
+
+    var error = result.FailureOrDefault();
+    error.Should().BeOfType<DomainProblemException>();
+    ((DomainProblemException)error).Problem.Should().BeOfType<EntityConflict>();
+    repo.Tags[TagId].UserId.Should().Be(Owner, "the original owner keeps the tag");
+  }
+
+  [Fact]
+  public async Task Link_HabitNotOwnedOrMissing_FailsWithNotFound()
+  {
+    var (svc, _, _) = Make();
+
+    var result = await svc.Link(Owner, TagId, HabitA);
+
+    result.FailureOrDefault().Should().BeOfType<NotFoundException>();
+  }
+
+  [Fact]
+  public async Task Resolve_OwnTag_ReturnsVersionAndTodayExecution()
+  {
+    var (svc, repo, habits) = Make();
+    var version = Version(HabitA);
+    habits.Versions[(Owner, HabitA)] = version;
+    await svc.Link(Owner, TagId, HabitA);
+
+    var tz = TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");
+    var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));
+    var execution = new HabitExecutionPrincipal
+    {
+      Id = Guid.NewGuid(),
+      HabitVersionId = version.Id,
+      Record = new HabitExecutionRecord { Date = today, Status = ExecutionStatus.Completed, CompletedAt = DateTime.UtcNow }
+    };
+    repo.Executions[(HabitA, today)] = execution;
+
+    var result = await svc.Resolve(Owner, TagId);
+
+    result.IsSuccess().Should().BeTrue();
+    var resolution = (NfcTagResolution?)result;
+    resolution.Should().NotBeNull();
+    resolution!.HabitVersion.Id.Should().Be(version.Id);
+    resolution.Today.Should().Be(today);
+    resolution.TodayExecution.Should().NotBeNull();
+    resolution.TodayExecution!.Record.Status.Should().Be(ExecutionStatus.Completed);
+  }
+
+  [Fact]
+  public async Task Resolve_NotActedOnToday_ReturnsNullExecution()
+  {
+    var (svc, _, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Resolve(Owner, TagId);
+
+    var resolution = (NfcTagResolution?)result;
+    resolution.Should().NotBeNull();
+    resolution!.TodayExecution.Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Resolve_UnclaimedTag_ReturnsNull()
+  {
+    var (svc, _, _) = Make();
+
+    var result = await svc.Resolve(Owner, TagId);
+
+    result.IsSuccess().Should().BeTrue();
+    ((NfcTagResolution?)result).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Resolve_TagOwnedByAnotherUser_ReturnsNullWithoutLeakingOwnership()
+  {
+    var (svc, _, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Resolve(Stranger, TagId);
+
+    result.IsSuccess().Should().BeTrue("foreign tags must look identical to unclaimed ones");
+    ((NfcTagResolution?)result).Should().BeNull();
+  }
+
+  [Fact]
+  public async Task Unlink_OwnTag_RemovesMapping()
+  {
+    var (svc, repo, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Unlink(Owner, TagId);
+
+    result.IsSuccess().Should().BeTrue();
+    ((CSharp_Result.Unit?)result).Should().NotBeNull();
+    repo.Tags.Should().BeEmpty();
+  }
+
+  [Fact]
+  public async Task Unlink_TagOwnedByAnotherUser_ReturnsNullAndKeepsMapping()
+  {
+    var (svc, repo, habits) = Make();
+    habits.Versions[(Owner, HabitA)] = Version(HabitA);
+    await svc.Link(Owner, TagId, HabitA);
+
+    var result = await svc.Unlink(Stranger, TagId);
+
+    result.IsSuccess().Should().BeTrue();
+    ((CSharp_Result.Unit?)result).Should().BeNull();
+    repo.Tags.Should().ContainKey(TagId);
+  }
+}


### PR DESCRIPTION
## What

New `NfcTag` module: maps a physical NFC tag's permanent random id (`lazytax.club/t/{tagId}`) to a user + habit, enabling tap-to-complete habits in neon.

ClickUp: [86ey8e6eh](https://app.clickup.com/t/86ey8e6eh) · Plan: NFC Habit Completion (v1)

## API (all Logto-authed, `/api/v1.0/NfcTag/{userId}/{tagId}`)

| Verb | Behavior |
|---|---|
| `PUT` | Link, create-or-replace. Unclaimed → claim; own tag → remap; another user's tag → **409 EntityConflict** (first-come-first-served, insert race covered by PK unique constraint) |
| `GET` | Resolve → habit's **current** `habitVersionId` + today's execution status (today computed in the habit's timezone). Owner only — unclaimed and foreign-owned tags both return 404 so ownership never leaks |
| `DELETE` | Unlink, owner only |

## Design notes

- Tag id is the **natural PK** (string from the tag URL); habit versioning is never stored on the tag — resolve always returns the current version
- Cascade on habit/user delete releases tags back to unclaimed (re-linkable)
- Completion itself reuses the existing `POST /Habit/{userId}/{habitVersionId}/executions` — untouched
- Module mirrors the Vacation module anatomy (Domain model/IService/IRepository + App Data/API/V1)

## Tests

- 10 unit tests: claim / remap / FCFS conflict / unknown habit / resolve owner-only + no-ownership-leak / today-execution / unlink
- Full suite green: 180 unit + 1 int (23 skipped, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pHz59ehHCiZz134oWxVeK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NFC tag management with API endpoints to link tags to habits, resolve a tag to habit details plus today’s completion status, and unlink tags.
  * Introduced NFC tag persistence with ownership enforcement and conflict handling.
  * Added request validation for NFC tag linkage and tag identifier format.

* **Bug Fixes**
  * Ensured soft-deleting a habit releases any previously linked NFC tags.

* **Tests**
  * Added unit and optional database-backed integration tests for linking, resolving, ownership conflicts, unlinking, and daily execution selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->