### PR TITLE
feat: show the habit name in penalty emails

### DIFF
--- a/App/Modules/Habit/Data/HabitRepository.cs
+++ b/App/Modules/Habit/Data/HabitRepository.cs
@@ -449,6 +449,22 @@ namespace App.Modules.Habit.Data
             }
         }
 
+        public async Task<Result<string?>> GetTaskNameByExecutionId(Guid executionId)
+        {
+            try
+            {
+                return await (from e in db.HabitExecutions
+                              join hv in db.HabitVersions on e.HabitVersionId equals hv.Id
+                              where e.Id == executionId
+                              select hv.Task).AsNoTracking().FirstOrDefaultAsync();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Failed to get task name for execution: {ExecutionId}", executionId);
+                throw;
+            }
+        }
+
         public async Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId)
         {
             try

--- a/App/Modules/Notification/EmailNotifier.cs
+++ b/App/Modules/Notification/EmailNotifier.cs
@@ -5,6 +5,7 @@ using App.StartUp.Registry;
 using App.StartUp.Smtp;
 using CSharp_Result;
 using Domain.Charity;
+using Domain.Habit;
 using Domain.Notification;
 using Domain.Subscription;
 using Domain.User;
@@ -18,6 +19,7 @@ public class EmailNotifier(
   ISmtpClientFactory factory,
   IUserRepository users,
   ICharityService charities,
+  IHabitRepository habits,
   ISubscriptionPlanProvider plans,
   IOptionsMonitor<WebPortalOption> portal,
   ILogger<EmailNotifier> logger
@@ -25,7 +27,8 @@ public class EmailNotifier(
 {
   public const string SupportEmail = "support@lazytax.club";
 
-  public async Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, DateTime chargedAtUtc)
+  public async Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, Guid habitExecutionId,
+    DateTime chargedAtUtc)
   {
     await this.SendSafe(userId, EmailTemplates.PenaltyCharged, EmailTemplates.PenaltyChargedSubject,
       async user => new
@@ -35,11 +38,13 @@ public class EmailNotifier(
         SupportEmail,
         Amount = FormatMoney(amount),
         CharityName = await this.CharityName(charityId),
+        HabitName = await this.HabitName(habitExecutionId),
         ChargeDate = FormatDate(chargedAtUtc),
       });
   }
 
-  public async Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, DateTime attemptedAtUtc)
+  public async Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, Guid habitExecutionId,
+    DateTime attemptedAtUtc)
   {
     await this.SendSafe(userId, EmailTemplates.PenaltyPaymentFailed, EmailTemplates.PenaltyPaymentFailedSubject,
       async user => new
@@ -49,6 +54,7 @@ public class EmailNotifier(
         SupportEmail,
         Amount = FormatMoney(amount),
         CharityName = await this.CharityName(charityId),
+        HabitName = await this.HabitName(habitExecutionId),
         AttemptDate = FormatDate(attemptedAtUtc),
       });
   }
@@ -210,6 +216,13 @@ public class EmailNotifier(
     var res = await charities.Get(charityId);
     var name = res.IsSuccess() ? res.Get()?.Principal.Record.Name : null;
     return string.IsNullOrWhiteSpace(name) ? "your chosen charity" : name;
+  }
+
+  private async Task<string> HabitName(Guid habitExecutionId)
+  {
+    var res = await habits.GetTaskNameByExecutionId(habitExecutionId);
+    var name = res.IsSuccess() ? res.Get() : null;
+    return string.IsNullOrWhiteSpace(name) ? "your habit" : name;
   }
 
   private string PlanPrice(string tier)

--- a/App/Modules/System/EmailController.cs
+++ b/App/Modules/System/EmailController.cs
@@ -32,6 +32,7 @@ public class EmailController(IEmailRenderer renderer, ISmtpClientFactory factory
       SupportEmail,
       Amount = "$5.00",
       CharityName = "Doctors Without Borders",
+      HabitName = "Morning run",
       ChargeDate = "12 July 2026",
     }),
     [EmailTemplates.PenaltyPaymentFailed] = (EmailTemplates.PenaltyPaymentFailedSubject, to => new
@@ -41,6 +42,7 @@ public class EmailController(IEmailRenderer renderer, ISmtpClientFactory factory
       SupportEmail,
       Amount = "$5.00",
       CharityName = "Doctors Without Borders",
+      HabitName = "Morning run",
       AttemptDate = "12 July 2026",
     }),
     [EmailTemplates.SubscriptionReceipt] = (EmailTemplates.SubscriptionReceiptSubject, to => new

--- a/App/Templates/Email/emails/penalty-charged.tsx
+++ b/App/Templates/Email/emails/penalty-charged.tsx
@@ -32,8 +32,8 @@ export const PenaltyChargedEmail = ({
     >
       <Headline>Your stake did some good, {userName}</Headline>
       <Paragraph>
-        You missed <b>{habitName}</b>, so your stake was charged and is headed to your chosen charity. That was the deal
-        — this isn&apos;t punishment, it&apos;s your commitment made real.
+        You missed {habitName}, so your stake was charged and is headed to your chosen charity. That was the deal — this
+        isn&apos;t punishment, it&apos;s your commitment made real.
       </Paragraph>
       <ReceiptCard
         amount={amount}

--- a/App/Templates/Email/emails/penalty-charged.tsx
+++ b/App/Templates/Email/emails/penalty-charged.tsx
@@ -10,6 +10,7 @@ interface PenaltyChargedEmailProps {
   supportEmail: string;
   amount: string;
   charityName: string;
+  habitName: string;
   chargeDate: string;
 }
 
@@ -19,6 +20,7 @@ export const PenaltyChargedEmail = ({
   supportEmail = '{{ supportEmail }}',
   amount = '{{ amount }}',
   charityName = '{{ charityName }}',
+  habitName = '{{ habitName }}',
   chargeDate = '{{ chargeDate }}',
 }: PenaltyChargedEmailProps) => {
   return (
@@ -30,15 +32,15 @@ export const PenaltyChargedEmail = ({
     >
       <Headline>Your stake did some good, {userName}</Headline>
       <Paragraph>
-        You missed a staked habit, so your stake was charged and is headed to your chosen charity. That was the deal —
-        this isn&apos;t punishment, it&apos;s your commitment made real.
+        You missed <b>{habitName}</b>, so your stake was charged and is headed to your chosen charity. That was the deal
+        — this isn&apos;t punishment, it&apos;s your commitment made real.
       </Paragraph>
       <ReceiptCard
         amount={amount}
         amountLabel="donated on your behalf"
         rows={[
           { label: 'Charity', value: charityName, emphasis: 'emerald' },
-          { label: 'Stake', value: amount },
+          { label: 'Habit', value: habitName },
           { label: 'Charged on', value: chargeDate },
           { label: 'Donation', value: '100% minus processing fees' },
         ]}
@@ -62,6 +64,7 @@ PenaltyChargedEmail.PreviewProps = {
   supportEmail: 'support@lazytax.club',
   amount: '$5.00',
   charityName: 'Doctors Without Borders',
+  habitName: 'Morning run',
   chargeDate: '12 July 2026',
 } as PenaltyChargedEmailProps;
 

--- a/App/Templates/Email/emails/penalty-payment-failed.tsx
+++ b/App/Templates/Email/emails/penalty-payment-failed.tsx
@@ -30,9 +30,7 @@ export const PenaltyPaymentFailedEmail = ({
       previewText={`Your ${amount} stake payment was declined`}
     >
       <Headline>Your stake payment didn&apos;t go through, {userName}</Headline>
-      <Paragraph>
-        We tried to charge your card for your <b>{habitName}</b> stake, but the payment was declined.
-      </Paragraph>
+      <Paragraph>We tried to charge your card for your {habitName} stake, but the payment was declined.</Paragraph>
       <ReceiptCard
         amount={amount}
         amountLabel="pending — payment declined"

--- a/App/Templates/Email/emails/penalty-payment-failed.tsx
+++ b/App/Templates/Email/emails/penalty-payment-failed.tsx
@@ -9,6 +9,7 @@ interface PenaltyPaymentFailedEmailProps {
   supportEmail: string;
   amount: string;
   charityName: string;
+  habitName: string;
   attemptDate: string;
 }
 
@@ -18,6 +19,7 @@ export const PenaltyPaymentFailedEmail = ({
   supportEmail = '{{ supportEmail }}',
   amount = '{{ amount }}',
   charityName = '{{ charityName }}',
+  habitName = '{{ habitName }}',
   attemptDate = '{{ attemptDate }}',
 }: PenaltyPaymentFailedEmailProps) => {
   return (
@@ -28,13 +30,15 @@ export const PenaltyPaymentFailedEmail = ({
       previewText={`Your ${amount} stake payment was declined`}
     >
       <Headline>Your stake payment didn&apos;t go through, {userName}</Headline>
-      <Paragraph>We tried to charge your card for your habit stake, but the payment was declined.</Paragraph>
+      <Paragraph>
+        We tried to charge your card for your <b>{habitName}</b> stake, but the payment was declined.
+      </Paragraph>
       <ReceiptCard
         amount={amount}
         amountLabel="pending — payment declined"
         rows={[
           { label: 'Charity', value: charityName },
-          { label: 'Amount due', value: amount },
+          { label: 'Habit', value: habitName },
           { label: 'Last attempt', value: attemptDate },
           { label: 'Status', value: 'Will retry automatically' },
         ]}
@@ -55,6 +59,7 @@ PenaltyPaymentFailedEmail.PreviewProps = {
   supportEmail: 'support@lazytax.club',
   amount: '$5.00',
   charityName: 'Doctors Without Borders',
+  habitName: 'Morning run',
   attemptDate: '12 July 2026',
 } as PenaltyPaymentFailedEmailProps;
 

--- a/Domain/Habit/Repository.cs
+++ b/Domain/Habit/Repository.cs
@@ -23,6 +23,8 @@ namespace Domain.Habit
         Task<Result<int>> CreateExecutionsForVersionsWithStatus(List<Guid> habitVersionIds, DateOnly date, ExecutionStatus status);
 
         // Habit Execution Methods
+        // Habit task name for an execution (penalty emails); null when the execution is gone.
+        Task<Result<string?>> GetTaskNameByExecutionId(Guid executionId);
         Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId);                    // Get current date in user's timezone
         Task<Result<HabitExecutionPrincipal>> CompleteHabit(string userId, Guid habitVersionId, DateOnly date, string? notes);
         Task<Result<HabitExecutionPrincipal>> SkipHabit(string userId, Guid habitVersionId, DateOnly date, string? notes);

--- a/Domain/Notification/IEmailNotifier.cs
+++ b/Domain/Notification/IEmailNotifier.cs
@@ -11,8 +11,8 @@ namespace Domain.Notification;
 /// </summary>
 public interface IEmailNotifier
 {
-  Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, DateTime chargedAtUtc);
-  Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, DateTime attemptedAtUtc);
+  Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime chargedAtUtc);
+  Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime attemptedAtUtc);
 
   /// <summary>First purchase or immediate upgrade receipt.</summary>
   Task NotifySubscriptionPurchased(string userId, string tier, Money amount, DateTime nextBillingUtc);

--- a/Domain/Penalty/Service.cs
+++ b/Domain/Penalty/Service.cs
@@ -87,7 +87,7 @@ public class PenaltyService(
         // of silently counting it as success.
         var charged = await repo.MarkCharged(p.Id, intent.Id).Then(_ => 1, Errors.MapAll);
         if (charged.IsSuccess())
-          await notifier.NotifyPenaltyCharged(rec.UserId, rec.Amount, rec.CharityId, DateTime.UtcNow);
+          await notifier.NotifyPenaltyCharged(rec.UserId, rec.Amount, rec.CharityId, rec.HabitExecutionId, DateTime.UtcNow);
         return charged;
       }
 
@@ -98,7 +98,7 @@ public class PenaltyService(
         var failed = await repo.MarkFailed(p.Id, $"Max attempts reached, last status {intent.Status}")
           .Then(_ => 1, Errors.MapAll);
         if (failed.IsSuccess())
-          await notifier.NotifyPenaltyFailed(rec.UserId, rec.Amount, rec.CharityId, DateTime.UtcNow);
+          await notifier.NotifyPenaltyFailed(rec.UserId, rec.Amount, rec.CharityId, rec.HabitExecutionId, DateTime.UtcNow);
         return failed;
       }
 
@@ -117,7 +117,7 @@ public class PenaltyService(
     {
       var failed = await repo.MarkFailed(p.Id, ex?.Message ?? "charge error").Then(_ => 1, Errors.MapAll);
       if (failed.IsSuccess())
-        await notifier.NotifyPenaltyFailed(rec.UserId, rec.Amount, rec.CharityId, DateTime.UtcNow);
+        await notifier.NotifyPenaltyFailed(rec.UserId, rec.Amount, rec.CharityId, rec.HabitExecutionId, DateTime.UtcNow);
       return failed;
     }
 

--- a/IntTest/Notification/NoopEmailNotifier.cs
+++ b/IntTest/Notification/NoopEmailNotifier.cs
@@ -6,8 +6,8 @@ namespace IntTest.Notification;
 // Integration tests exercise money persistence, not email delivery.
 public sealed class NoopEmailNotifier : IEmailNotifier
 {
-  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, DateTime chargedAtUtc) => Task.CompletedTask;
-  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, DateTime attemptedAtUtc) => Task.CompletedTask;
+  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime chargedAtUtc) => Task.CompletedTask;
+  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime attemptedAtUtc) => Task.CompletedTask;
   public Task NotifySubscriptionPurchased(string userId, string tier, Money amount, DateTime nextBillingUtc) => Task.CompletedTask;
   public Task NotifySubscriptionRenewed(string userId, string tier, DateTime nextBillingUtc) => Task.CompletedTask;
   public Task NotifySubscriptionPaymentFailed(string userId, string tier, DateTime graceEndsUtc) => Task.CompletedTask;

--- a/UnitTest/Notification/EmailTemplateRenderTests.cs
+++ b/UnitTest/Notification/EmailTemplateRenderTests.cs
@@ -19,6 +19,7 @@ public class EmailTemplateRenderTests
     SupportEmail = "support@lazytax.club",
     Amount = "$5.00",
     CharityName = "Doctors Without Borders",
+    HabitName = "Morning run",
     ChargeDate = "12 July 2026",
     AttemptDate = "12 July 2026",
     Tier = "Pro",

--- a/UnitTest/Notification/Fakes.cs
+++ b/UnitTest/Notification/Fakes.cs
@@ -18,13 +18,13 @@ public sealed class RecordingEmailNotifier : IEmailNotifier
   public List<(string UserId, string Email, string Username)> Welcome { get; } = [];
   public List<(string UserId, bool Linked, string Purpose)> ConsentChanged { get; } = [];
 
-  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, DateTime chargedAtUtc)
+  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime chargedAtUtc)
   {
     PenaltyCharged.Add((userId, amount, charityId));
     return Task.CompletedTask;
   }
 
-  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, DateTime attemptedAtUtc)
+  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime attemptedAtUtc)
   {
     PenaltyFailed.Add((userId, amount, charityId));
     return Task.CompletedTask;
@@ -82,8 +82,8 @@ public sealed class ThrowingEmailNotifier : IEmailNotifier
 {
   private Task Boom() => throw new InvalidOperationException("email infrastructure down");
 
-  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, DateTime chargedAtUtc) => this.Boom();
-  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, DateTime attemptedAtUtc) => this.Boom();
+  public Task NotifyPenaltyCharged(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime chargedAtUtc) => this.Boom();
+  public Task NotifyPenaltyFailed(string userId, Money amount, Guid charityId, Guid habitExecutionId, DateTime attemptedAtUtc) => this.Boom();
   public Task NotifySubscriptionPurchased(string userId, string tier, Money amount, DateTime nextBillingUtc) => this.Boom();
   public Task NotifySubscriptionRenewed(string userId, string tier, DateTime nextBillingUtc) => this.Boom();
   public Task NotifySubscriptionPaymentFailed(string userId, string tier, DateTime graceEndsUtc) => this.Boom();

--- a/UnitTest/Protection/Fakes.cs
+++ b/UnitTest/Protection/Fakes.cs
@@ -136,6 +136,9 @@ public sealed class FakeHabitRepository(CallLog? log = null) : IHabitRepository
     return Task.FromResult<Result<List<FailedExecutionRow>>>(rows);
   }
 
+  public Task<Result<string?>> GetTaskNameByExecutionId(Guid executionId)
+    => Task.FromResult<Result<string?>>((string?)null);
+
   public Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId)
     => Task.FromResult<Result<DateOnly>>(CurrentDate);
 

--- a/UnitTest/Protection/SkipLimitTests.cs
+++ b/UnitTest/Protection/SkipLimitTests.cs
@@ -204,6 +204,7 @@ internal sealed class FakeSkipCountRepository(int usedSkips) : IHabitRepository
   public Task<Result<Unit?>> Delete(Guid habitId, string userId) => throw new NotImplementedException();
   public Task<Result<List<FailedExecutionRow>>> CreateFailedExecutions(List<Guid> habitIds, DateOnly date) => throw new NotImplementedException();
   public Task<Result<int>> CreateExecutionsForVersionsWithStatus(List<Guid> habitVersionIds, DateOnly date, ExecutionStatus status) => throw new NotImplementedException();
+  public Task<Result<string?>> GetTaskNameByExecutionId(Guid executionId) => throw new NotImplementedException();
   public Task<Result<DateOnly>> GetUserCurrentDate(string userId, Guid habitVersionId) => throw new NotImplementedException();
   public Task<Result<HabitExecutionPrincipal>> CompleteHabit(string userId, Guid habitVersionId, DateOnly date, string? notes) => throw new NotImplementedException();
   public Task<Result<HabitExecutionPrincipal>> SkipHabit(string userId, Guid habitVersionId, DateOnly date, string? notes) => throw new NotImplementedException();


### PR DESCRIPTION
Follow-up to #72 (approved by @speedykrab): penalty emails now name the missed habit.

- `IHabitRepository.GetTaskNameByExecutionId` — execution → version join for the task name
- `EmailNotifier` resolves it (falls back to "your habit" if the habit is gone); `IEmailNotifier` penalty methods take `habitExecutionId`
- `penalty-charged` / `penalty-payment-failed` templates: lead sentence names the habit, redundant STAKE/AMOUNT-DUE grid cell becomes HABIT (amount is already the headline number)
- Also carries the CodeRabbit nit fix from #72 (subject constant)

212 unit tests green (render smoke includes the new `{{ habitName }}` var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UG2z4Cy2AdSxvCtKGxvHTJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Penalty emails now identify the specific habit associated with the charge or failed payment.
  * Email receipts include a dedicated habit field and updated messaging.
  * Missing habit names use a fallback value to keep notifications complete.

* **Tests**
  * Updated email previews and rendering coverage to validate habit-specific content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->