### PR TITLE
feat: penalty kill-switch so promotes cannot silently start deducting

### DIFF
--- a/App/Config/settings.pichu.yaml
+++ b/App/Config/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Auto-deduction: pichu's Airwallex points at the demo environment, so charging
+# stored consents here moves no real money.
+Penalty:
+  Enabled: true
+
 # Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
 # run the disbursement worker here. Donations hit the Pledge sandbox, never production.
 Disbursement:

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -234,6 +234,12 @@ Payment:
     Webhook: 'webhook-secret-key'
 # Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
 # environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+# Auto-deduction kill-switch: the penalty processor charges real cards via
+# stored Airwallex consents, so it is off unless a landscape deliberately opts
+# in. Penalties still accrue while off; enabling drains the backlog.
+Penalty:
+  Enabled: false
+
 Disbursement:
   Enabled: false
   MinPayoutCents: 0

--- a/App/Config/settings.yaml
+++ b/App/Config/settings.yaml
@@ -232,14 +232,14 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
-# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
-# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 # Auto-deduction kill-switch: the penalty processor charges real cards via
 # stored Airwallex consents, so it is off unless a landscape deliberately opts
 # in. Penalties still accrue while off; enabling drains the backlog.
 Penalty:
   Enabled: false
 
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 Disbursement:
   Enabled: false
   MinPayoutCents: 0

--- a/App/Modules/Penalty/PenaltyProcessorHostedService.cs
+++ b/App/Modules/Penalty/PenaltyProcessorHostedService.cs
@@ -1,9 +1,12 @@
+using App.StartUp.Options;
 using Domain.Penalty;
+using Microsoft.Extensions.Options;
 
 namespace App.Modules.Penalty;
 
 public class PenaltyProcessorHostedService(
   IServiceProvider serviceProvider,
+  IOptionsMonitor<PenaltyOption> options,
   ILogger<PenaltyProcessorHostedService> logger
 ) : IHostedService, IDisposable
 {
@@ -18,6 +21,12 @@ public class PenaltyProcessorHostedService(
 
   public Task StartAsync(CancellationToken cancellationToken)
   {
+    if (!options.CurrentValue.Enabled)
+    {
+      logger.LogInformation("PenaltyProcessorHostedService disabled (Penalty.Enabled=false); not scheduling");
+      return Task.CompletedTask;
+    }
+
     // Drain pending penalties every 15 minutes. Larger initial delay than the
     // failure job so daily failures are marked (enqueued) before draining.
     _timer = new Timer(async _ => await DoWork(), null, TimeSpan.FromMinutes(3), TimeSpan.FromMinutes(15));

--- a/App/StartUp/Options/OptionsExtensions.cs
+++ b/App/StartUp/Options/OptionsExtensions.cs
@@ -147,6 +147,9 @@ public static class OptionsExtensions
     // Register Disbursement (charity payout) Options
     services.RegisterOption<DisbursementOption>(DisbursementOption.Key);
 
+    // Register Penalty (auto-deduction) Options
+    services.RegisterOption<PenaltyOption>(PenaltyOption.Key);
+
     // Register Subscription (tier catalog + renewal) Options.
     // Note: the free tier deliberately sits below the pre-subscription stub
     // defaults (product decision 2026-07-06: free = 2 habits, no vacation/

--- a/App/StartUp/Options/PenaltyOption.cs
+++ b/App/StartUp/Options/PenaltyOption.cs
@@ -1,0 +1,16 @@
+namespace App.StartUp.Options;
+
+// Penalty (auto-deduction) settings. The processor charges failed staked habits
+// against the user's stored Airwallex consent — real money movement — so it
+// only runs where deliberately enabled.
+public class PenaltyOption
+{
+  public const string Key = "Penalty";
+
+  // Master switch for the background charge worker. Off by default so promoting
+  // a landscape can never silently start deducting money (e.g. raichu while the
+  // Airwallex account migration is in flight). Failure marking still runs and
+  // penalties still accrue while disabled — flipping this on later drains that
+  // backlog, so clear stale penalties first if that is not intended.
+  public bool Enabled { get; set; } = false;
+}

--- a/infra/api_chart/app/settings.pichu.yaml
+++ b/infra/api_chart/app/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Auto-deduction: pichu's Airwallex points at the demo environment, so charging
+# stored consents here moves no real money.
+Penalty:
+  Enabled: true
+
 # Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
 # run the disbursement worker here. Donations hit the Pledge sandbox, never production.
 Disbursement:

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -234,6 +234,12 @@ Payment:
     Webhook: 'webhook-secret-key'
 # Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
 # environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+# Auto-deduction kill-switch: the penalty processor charges real cards via
+# stored Airwallex consents, so it is off unless a landscape deliberately opts
+# in. Penalties still accrue while off; enabling drains the backlog.
+Penalty:
+  Enabled: false
+
 Disbursement:
   Enabled: false
   MinPayoutCents: 0

--- a/infra/api_chart/app/settings.yaml
+++ b/infra/api_chart/app/settings.yaml
@@ -232,14 +232,14 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
-# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
-# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 # Auto-deduction kill-switch: the penalty processor charges real cards via
 # stored Airwallex consents, so it is off unless a landscape deliberately opts
 # in. Penalties still accrue while off; enabling drains the backlog.
 Penalty:
   Enabled: false
 
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 Disbursement:
   Enabled: false
   MinPayoutCents: 0

--- a/infra/migration_chart/app/settings.pichu.yaml
+++ b/infra/migration_chart/app/settings.pichu.yaml
@@ -44,6 +44,11 @@ HttpClient:
     BaseAddress: 'https://api-demo.airwallex.com'
     Timeout: 60
 
+# Auto-deduction: pichu's Airwallex points at the demo environment, so charging
+# stored consents here moves no real money.
+Penalty:
+  Enabled: true
+
 # Charity payout: pichu's Pledge points at staging (api-staging.pledge.to), so it is safe to
 # run the disbursement worker here. Donations hit the Pledge sandbox, never production.
 Disbursement:

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -234,6 +234,12 @@ Payment:
     Webhook: 'webhook-secret-key'
 # Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
 # environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
+# Auto-deduction kill-switch: the penalty processor charges real cards via
+# stored Airwallex consents, so it is off unless a landscape deliberately opts
+# in. Penalties still accrue while off; enabling drains the backlog.
+Penalty:
+  Enabled: false
+
 Disbursement:
   Enabled: false
   MinPayoutCents: 0

--- a/infra/migration_chart/app/settings.yaml
+++ b/infra/migration_chart/app/settings.yaml
@@ -232,14 +232,14 @@ Payment:
     Id: 'your-airwallex-client-id'
     Key: 'your-airwallex-api-key'
     Webhook: 'webhook-secret-key'
-# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
-# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 # Auto-deduction kill-switch: the penalty processor charges real cards via
 # stored Airwallex consents, so it is off unless a landscape deliberately opts
 # in. Penalties still accrue while off; enabling drains the backlog.
 Penalty:
   Enabled: false
 
+# Charity payout worker. Disabled by default; landscapes that point Pledge at a safe
+# environment (e.g. pichu -> api-staging.pledge.to) enable it via their override file.
 Disbursement:
   Enabled: false
   MinPayoutCents: 0


### PR DESCRIPTION
## What

A landscape-scoped master switch for the **auto-deduction** worker, mirroring the existing `Disbursement.Enabled` pattern:

- New `PenaltyOption` (`Penalty.Enabled`, **default: false**) — `PenaltyProcessorHostedService` simply doesn't schedule when off, with a clear log line
- `settings.yaml`: `Penalty.Enabled: false` (base default)
- `settings.pichu.yaml`: `Penalty.Enabled: true` (Airwallex demo — no real money)
- pikachu/raichu inherit **off**

## Why

raichu is still on zinc v1.20.0 (pre-penalty). Promoting it would otherwise unconditionally start the charge worker (`Server.cs` registers it with no gate) against whatever consents exist — mid-Airwallex-account-migration that's a silent money-movement risk. With this flag, the raichu promote ships the worker dark; deduction is turned on deliberately (config change) once the new Airwallex account + Pledge prod key are in place.

Note: failure marking still runs and penalties still **accrue** while disabled — enabling later drains the backlog (documented on the option). Clear stale penalties first if that's not intended.

## Verification

- `dotnet build`: clean (0 errors)
- `dotnet test UnitTest`: 212 passed / 1 pre-existing skip
- Config sync hook propagated the settings into `infra/{api,migration}_chart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pHz59ehHCiZz134oWxVeK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a master “Penalty” kill-switch to control the background penalty processor.
  * When the switch is off, the processor won’t start its periodic draining work (penalties can still accrue).
  * Added the same configurable setting across application and chart environments, with demo configurations enabling it for testing.
* **Documentation**
  * Included configuration comments clarifying demo/payment behavior and default disablement intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->