### PR TITLE
Subscription event history (append-only) + events endpoint

### DIFF
--- a/App/Migrations/20260801162330_AddSubscriptionEvents.Designer.cs
+++ b/App/Migrations/20260801162330_AddSubscriptionEvents.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using App.StartUp.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace App.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260801162330_AddSubscriptionEvents")]
+    partial class AddSubscriptionEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/App/Migrations/20260801162330_AddSubscriptionEvents.cs
+++ b/App/Migrations/20260801162330_AddSubscriptionEvents.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace App.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSubscriptionEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SubscriptionEvents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    EventType = table.Column<int>(type: "integer", nullable: false),
+                    OccurredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Tier = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    NextTier = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    AmountCents = table.Column<int>(type: "integer", nullable: true),
+                    Currency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: true),
+                    ChargeIntentId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    PeriodEnd = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Detail = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SubscriptionEvents", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SubscriptionEvents_UserId_OccurredAt",
+                table: "SubscriptionEvents",
+                columns: ["UserId", "OccurredAt"]);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SubscriptionEvents");
+        }
+    }
+}

--- a/App/Modules/DomainServices.cs
+++ b/App/Modules/DomainServices.cs
@@ -128,6 +128,9 @@ public static class DomainServices
     s.AddScoped<ISubscriptionRepository, SubscriptionRepository>()
       .AutoTrace<ISubscriptionRepository>();
 
+    s.AddScoped<ISubscriptionEventRepository, SubscriptionEventRepository>()
+      .AutoTrace<ISubscriptionEventRepository>();
+
     s.AddScoped<ISubscriptionPlanProvider, SubscriptionPlanProvider>()
       .AutoTrace<ISubscriptionPlanProvider>();
 

--- a/App/Modules/Subscription/API/V1/SubscriptionController.cs
+++ b/App/Modules/Subscription/API/V1/SubscriptionController.cs
@@ -19,6 +19,7 @@ namespace App.Modules.Subscription.API.V1;
 [Route("api/v{version:apiVersion}/[controller]")]
 public class SubscriptionController(
   ISubscriptionRepository subscriptionRepository,
+  ISubscriptionEventRepository eventRepository,
   ISubscriptionManagementService managementService,
   IWebHandoffService webHandoffService,
   IAuthHelper authHelper,
@@ -61,6 +62,19 @@ public class SubscriptionController(
     var result = await this.GuardAsync(userId)
       .ThenAwait(_ => subscriptionRepository.GetByUserId(userId))
       .Then(sub => sub?.ToRes() ?? SubscriptionMapper.ToFreeRes(userId), Errors.MapNone);
+
+    return this.ReturnResult(result);
+  }
+
+  // Billing/lifecycle history, newest first — the data behind receipts and the
+  // billing-history page. Append-only server-side, read-only here.
+  [Authorize, HttpGet("{userId}/events")]
+  public async Task<ActionResult<List<SubscriptionEventRes>>> Events(string userId, [FromQuery] int limit = 50)
+  {
+    var clamped = Math.Clamp(limit, 1, 200);
+    var result = await this.GuardAsync(userId)
+      .ThenAwait(_ => eventRepository.ListByUser(userId, clamped))
+      .Then(list => list.Select(e => e.ToRes()).ToList(), Errors.MapNone);
 
     return this.ReturnResult(result);
   }

--- a/App/Modules/Subscription/API/V1/SubscriptionMapper.cs
+++ b/App/Modules/Subscription/API/V1/SubscriptionMapper.cs
@@ -53,4 +53,21 @@ public static class SubscriptionMapper
       rec.NextTier
     );
   }
+
+  public static SubscriptionEventRes ToRes(this SubscriptionEventPrincipal p)
+  {
+    var rec = p.Record;
+    return new SubscriptionEventRes(
+      // camelCase over the wire, e.g. DowngradeScheduled -> "downgradeScheduled"
+      char.ToLowerInvariant(rec.EventType.ToString()[0]) + rec.EventType.ToString()[1..],
+      rec.OccurredAt.ToString("O"),
+      rec.Tier,
+      rec.NextTier,
+      rec.AmountCents,
+      rec.Currency,
+      rec.ChargeIntentId,
+      rec.PeriodEnd?.ToString("O"),
+      rec.Detail
+    );
+  }
 }

--- a/App/Modules/Subscription/API/V1/SubscriptionModel.cs
+++ b/App/Modules/Subscription/API/V1/SubscriptionModel.cs
@@ -34,3 +34,17 @@ public record SubscriptionRes(
   bool CancelAtPeriodEnd,
   string? NextTier
 );
+
+// One row of the append-only billing/lifecycle history, newest first.
+// AmountCents/Currency/ChargeIntentId are set on money events only.
+public record SubscriptionEventRes(
+  string EventType,
+  string OccurredAt,
+  string Tier,
+  string? NextTier,
+  int? AmountCents,
+  string? Currency,
+  string? ChargeIntentId,
+  string? PeriodEnd,
+  string? Detail
+);

--- a/App/Modules/Subscription/Data/SubscriptionEventData.cs
+++ b/App/Modules/Subscription/Data/SubscriptionEventData.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace App.Modules.Subscription.Data
+{
+    // Append-only subscription lifecycle history. Rows are never updated or
+    // deleted — no UpdatedAt, no soft delete. See Domain/Subscription/EventModel.cs.
+    public class SubscriptionEventData
+    {
+        [Key]
+        public Guid Id { get; set; }
+        [MaxLength(128)]
+        public required string UserId { get; set; }
+        public required int EventType { get; set; }
+        public required DateTime OccurredAt { get; set; } // UTC
+        [MaxLength(64)]
+        public required string Tier { get; set; }
+        [MaxLength(64)]
+        public string? NextTier { get; set; }
+        public int? AmountCents { get; set; }
+        [MaxLength(8)]
+        public string? Currency { get; set; }
+        [MaxLength(256)]
+        public string? ChargeIntentId { get; set; }
+        public DateTime? PeriodEnd { get; set; }
+        [MaxLength(512)]
+        public string? Detail { get; set; }
+    }
+}

--- a/App/Modules/Subscription/Data/SubscriptionEventMapper.cs
+++ b/App/Modules/Subscription/Data/SubscriptionEventMapper.cs
@@ -1,0 +1,50 @@
+using Domain.Subscription;
+
+namespace App.Modules.Subscription.Data
+{
+    public static class SubscriptionEventMapper
+    {
+        public static SubscriptionEventData ToData(this SubscriptionEventRecord record)
+        {
+            return new SubscriptionEventData
+            {
+                UserId = record.UserId,
+                EventType = (int)record.EventType,
+                OccurredAt = record.OccurredAt,
+                Tier = record.Tier,
+                NextTier = record.NextTier,
+                AmountCents = record.AmountCents,
+                Currency = record.Currency,
+                ChargeIntentId = record.ChargeIntentId,
+                PeriodEnd = record.PeriodEnd,
+                Detail = record.Detail
+            };
+        }
+
+        public static SubscriptionEventRecord ToRecord(this SubscriptionEventData data)
+        {
+            return new SubscriptionEventRecord
+            {
+                UserId = data.UserId,
+                EventType = (SubscriptionEventType)data.EventType,
+                OccurredAt = data.OccurredAt,
+                Tier = data.Tier,
+                NextTier = data.NextTier,
+                AmountCents = data.AmountCents,
+                Currency = data.Currency,
+                ChargeIntentId = data.ChargeIntentId,
+                PeriodEnd = data.PeriodEnd,
+                Detail = data.Detail
+            };
+        }
+
+        public static SubscriptionEventPrincipal ToPrincipal(this SubscriptionEventData data)
+        {
+            return new SubscriptionEventPrincipal
+            {
+                Id = data.Id,
+                Record = data.ToRecord()
+            };
+        }
+    }
+}

--- a/App/Modules/Subscription/Data/SubscriptionEventRepository.cs
+++ b/App/Modules/Subscription/Data/SubscriptionEventRepository.cs
@@ -1,0 +1,47 @@
+using App.StartUp.Database;
+using CSharp_Result;
+using Domain.Subscription;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Modules.Subscription.Data
+{
+    public class SubscriptionEventRepository(MainDbContext db, ILogger<SubscriptionEventRepository> logger)
+        : ISubscriptionEventRepository
+    {
+        public async Task<Result<SubscriptionEventPrincipal>> Append(SubscriptionEventRecord record)
+        {
+            try
+            {
+                var data = record.ToData();
+                db.SubscriptionEvents.Add(data);
+                await db.SaveChangesAsync();
+                return data.ToPrincipal();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "Append subscription event failed for UserId={UserId}, EventType={EventType}",
+                    record.UserId, record.EventType);
+                throw;
+            }
+        }
+
+        public async Task<Result<List<SubscriptionEventPrincipal>>> ListByUser(string userId, int limit)
+        {
+            try
+            {
+                var rows = await db.SubscriptionEvents.AsNoTracking()
+                    .Where(x => x.UserId == userId)
+                    .OrderByDescending(x => x.OccurredAt)
+                    .ThenByDescending(x => x.Id)
+                    .Take(limit)
+                    .ToListAsync();
+                return rows.Select(x => x.ToPrincipal()).ToList();
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "ListByUser subscription events failed for UserId={UserId}", userId);
+                throw;
+            }
+        }
+    }
+}

--- a/App/StartUp/Database/MainDbContext.cs
+++ b/App/StartUp/Database/MainDbContext.cs
@@ -49,6 +49,8 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
   public DbSet<DisbursementData> Disbursements { get; set; }
   // Subscription (paid tiers)
   public DbSet<UserSubscriptionData> UserSubscriptions { get; set; }
+  // Subscription lifecycle history (append-only)
+  public DbSet<SubscriptionEventData> SubscriptionEvents { get; set; }
   // NFC tags (physical tag → habit mapping)
   public DbSet<NfcTagData> NfcTags { get; set; }
   // public DbSet<CompletionData> Completions { get; set; }
@@ -207,5 +209,13 @@ public class MainDbContext(IOptionsMonitor<Dictionary<string, DatabaseOption>> o
                 .WithMany()
                 .HasForeignKey(x => x.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
+
+    // Subscription lifecycle history: append-only, so only the billing-history
+    // read path (newest first per user) needs an index. Deliberately no FK to
+    // Users: financial history must survive account deletion.
+    // TODO(account-deletion): anonymize-retain UserId here (sentinel, keep the
+    // money fields) alongside the penalty-ledger seam in UserRepository.
+    var subscriptionEvent = modelBuilder.Entity<SubscriptionEventData>();
+    subscriptionEvent.HasIndex(x => new { x.UserId, x.OccurredAt });
   }
 }

--- a/Domain/Subscription/EventModel.cs
+++ b/Domain/Subscription/EventModel.cs
@@ -1,0 +1,57 @@
+namespace Domain.Subscription;
+
+// One immutable row per subscription lifecycle event. The UserSubscriptions row
+// stays the single source of CURRENT truth; this table is the history — it
+// powers receipts/billing history, audit ("did we ever schedule this
+// downgrade?"), and gives failed side-effects (e.g. a pause reconcile after a
+// lapse) a durable record to retry from. Rows are never updated or deleted.
+public enum SubscriptionEventType
+{
+  // First activation, or re-activation after Cancelled. Money event.
+  Activated,
+  // Immediate tier switch on an active row (prorated, possibly $0). Money event.
+  Upgraded,
+  // NextTier set; applies at the period roll.
+  DowngradeScheduled,
+  // NextTier cleared before it applied.
+  DowngradeUndone,
+  // CancelAtPeriodEnd set; access retained until PeriodEnd.
+  CancelScheduled,
+  // CancelAtPeriodEnd cleared before the period ended.
+  Resumed,
+  // Period rolled after a successful renewal charge (a scheduled downgrade
+  // lands here — Tier is the tier just applied). Money event.
+  Renewed,
+  // A charge attempt did not settle (interactive subscribe or renewal retry).
+  ChargeFailed,
+  // Renewal failed and the row entered the grace window (fires once per lapse).
+  GraceEntered,
+  // Grace window exhausted; effective access dropped to free.
+  Lapsed,
+  // A user-requested cancel took effect at the period roll.
+  Cancelled
+}
+
+public record SubscriptionEventRecord
+{
+  public required string UserId { get; init; }
+  public required SubscriptionEventType EventType { get; init; }
+  public required DateTime OccurredAt { get; init; } // UTC
+  // Tier snapshot at the moment of the event (the tier the event concerns).
+  public required string Tier { get; init; }
+  public string? NextTier { get; init; }
+  // Money events only.
+  public int? AmountCents { get; init; }
+  public string? Currency { get; init; }
+  public string? ChargeIntentId { get; init; }
+  // The period end this event relates to (renewal anchor / access-until).
+  public DateTime? PeriodEnd { get; init; }
+  // Small human-readable context, e.g. the gateway status of a failed charge.
+  public string? Detail { get; init; }
+}
+
+public record SubscriptionEventPrincipal
+{
+  public required Guid Id { get; init; }
+  public required SubscriptionEventRecord Record { get; init; }
+}

--- a/Domain/Subscription/IEventRepository.cs
+++ b/Domain/Subscription/IEventRepository.cs
@@ -1,0 +1,11 @@
+using CSharp_Result;
+
+namespace Domain.Subscription;
+
+public interface ISubscriptionEventRepository
+{
+  // Append-only: there is deliberately no update or delete.
+  Task<Result<SubscriptionEventPrincipal>> Append(SubscriptionEventRecord record);
+  // Newest first, for the billing-history surface.
+  Task<Result<List<SubscriptionEventPrincipal>>> ListByUser(string userId, int limit);
+}

--- a/Domain/Subscription/ManagementService.cs
+++ b/Domain/Subscription/ManagementService.cs
@@ -14,9 +14,31 @@ public class SubscriptionManagementService(
   IPaymentService payment,
   IEmailNotifier notifier,
   IEntitlementService entitlements,
+  ISubscriptionEventRepository events,
   ILogger<SubscriptionManagementService> logger
 ) : ISubscriptionManagementService
 {
+  // Append a lifecycle event to the immutable history. Best-effort by contract:
+  // the state/money write it describes has already committed, so a failed
+  // append must never fail the flow — it only costs a history row.
+  private async Task LogEventSafe(SubscriptionEventRecord record)
+  {
+    try
+    {
+      var appended = await events.Append(record);
+      if (!appended.IsSuccess())
+        logger.LogWarning(appended.FailureOrDefault(),
+          "Subscription event append failed for {UserId} ({EventType})", record.UserId, record.EventType);
+    }
+    catch (Exception ex)
+    {
+      logger.LogWarning(ex,
+        "Subscription event append threw for {UserId} ({EventType})", record.UserId, record.EventType);
+    }
+  }
+
+  private static int ToCents(NodaMoney.Money money) => (int)Math.Round(money.Amount * 100m);
+
   // Re-align over-cap habit pausing after a tier change lands. Best-effort by
   // design: the money has already moved, so a pause failure must never fail the
   // subscription flow — the next tier event (or renewal roll) re-reconciles.
@@ -54,9 +76,21 @@ public class SubscriptionManagementService(
     {
       // Re-subscribing the same tier after a pending cancel = un-cancel, free of charge.
       if (existing.Record.CancelAtPeriodEnd)
-        return await repo.SetCancelAtPeriodEnd(existing.Id, false)
+      {
+        var resumed = await repo.SetCancelAtPeriodEnd(existing.Id, false)
           .ThenAwait(_ => repo.GetByUserId(userId))
           .Then(s => s!, Errors.MapNone);
+        if (resumed.IsSuccess())
+          await this.LogEventSafe(new SubscriptionEventRecord
+          {
+            UserId = userId,
+            EventType = SubscriptionEventType.Resumed,
+            OccurredAt = DateTime.UtcNow,
+            Tier = tier,
+            PeriodEnd = existing.Record.PeriodEnd
+          });
+        return resumed;
+      }
 
       return new AlreadySubscribedException(existing.Record.Tier, tier);
     }
@@ -159,6 +193,17 @@ public class SubscriptionManagementService(
       if (!flipped.IsSuccess()) return flipped.FailureOrDefault()!;
       if (!flipped.Get()) return new SubscriptionBusyException(userId);
       await this.ReconcileHabitPauseSafe(userId, tier);
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = userId,
+        EventType = SubscriptionEventType.Upgraded,
+        OccurredAt = DateTime.UtcNow,
+        Tier = tier,
+        AmountCents = 0,
+        Currency = chargeAmount.Currency.Code,
+        PeriodEnd = periodEnd,
+        Detail = "prorated to zero at the renewal boundary"
+      });
       return await repo.GetByUserId(userId).Then(s => s!, Errors.MapNone);
     }
 
@@ -189,7 +234,20 @@ public class SubscriptionManagementService(
 
     var intent = chargeRes.Get();
     if (intent.Status != "SUCCEEDED")
+    {
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = userId,
+        EventType = SubscriptionEventType.ChargeFailed,
+        OccurredAt = DateTime.UtcNow,
+        Tier = tier,
+        AmountCents = ToCents(chargeAmount),
+        Currency = chargeAmount.Currency.Code,
+        ChargeIntentId = intent.Id,
+        Detail = intent.Status
+      });
       return new SubscriptionChargeFailedException(intent.Status);
+    }
 
     var activated = await repo.Activate(rowId, tier, periodStart, periodEnd, DateTime.UtcNow);
     if (!activated.IsSuccess()) return activated.FailureOrDefault()!;
@@ -206,6 +264,17 @@ public class SubscriptionManagementService(
     }
 
     await this.ReconcileHabitPauseSafe(userId, tier);
+    await this.LogEventSafe(new SubscriptionEventRecord
+    {
+      UserId = userId,
+      EventType = isTierSwitch ? SubscriptionEventType.Upgraded : SubscriptionEventType.Activated,
+      OccurredAt = DateTime.UtcNow,
+      Tier = tier,
+      AmountCents = ToCents(chargeAmount),
+      Currency = chargeAmount.Currency.Code,
+      ChargeIntentId = intent.Id,
+      PeriodEnd = periodEnd
+    });
 
     var result = await repo.GetByUserId(userId).Then(s => s!, Errors.MapNone);
     if (result.IsSuccess())
@@ -226,8 +295,18 @@ public class SubscriptionManagementService(
       .ThenAwait(_ => repo.GetByUserId(userId))
       .Then(s => s!, Errors.MapNone);
     if (cancelled.IsSuccess())
+    {
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = userId,
+        EventType = SubscriptionEventType.CancelScheduled,
+        OccurredAt = DateTime.UtcNow,
+        Tier = existing.Record.Tier,
+        PeriodEnd = existing.Record.PeriodEnd
+      });
       await notifier.NotifySubscriptionChanged(
         userId, existing.Record.Tier, SubscriptionService.FreeTier, existing.Record.PeriodEnd);
+    }
     return cancelled;
   }
 
@@ -251,6 +330,20 @@ public class SubscriptionManagementService(
         var uncancel = await repo.SetCancelAtPeriodEnd(existing.Id, false);
         if (!uncancel.IsSuccess()) return uncancel.FailureOrDefault()!;
       }
+
+      // CancelAtPeriodEnd and NextTier are mutually exclusive (downgrades
+      // supersede cancels), so exactly one of these describes the undo.
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = userId,
+        EventType = existing.Record.CancelAtPeriodEnd
+          ? SubscriptionEventType.Resumed
+          : SubscriptionEventType.DowngradeUndone,
+        OccurredAt = DateTime.UtcNow,
+        Tier = tier,
+        NextTier = existing.Record.NextTier,
+        PeriodEnd = existing.Record.PeriodEnd
+      });
 
       return await repo.GetByUserId(userId).Then(s => s!, Errors.MapNone);
     }
@@ -276,7 +369,18 @@ public class SubscriptionManagementService(
 
     var scheduled = await repo.GetByUserId(userId).Then(s => s!, Errors.MapNone);
     if (scheduled.IsSuccess())
+    {
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = userId,
+        EventType = SubscriptionEventType.DowngradeScheduled,
+        OccurredAt = DateTime.UtcNow,
+        Tier = existing.Record.Tier,
+        NextTier = tier,
+        PeriodEnd = existing.Record.PeriodEnd
+      });
       await notifier.NotifySubscriptionChanged(userId, existing.Record.Tier, tier, existing.Record.PeriodEnd);
+    }
     return scheduled;
   }
 
@@ -336,6 +440,14 @@ public class SubscriptionManagementService(
       var cancelled = await repo.MarkCancelled(sub.Id);
       if (!cancelled.IsSuccess()) return cancelled.FailureOrDefault()!;
       await this.ReconcileHabitPauseSafe(rec.UserId, SubscriptionService.FreeTier);
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = rec.UserId,
+        EventType = SubscriptionEventType.Cancelled,
+        OccurredAt = nowUtc,
+        Tier = rec.Tier,
+        PeriodEnd = rec.PeriodEnd
+      });
       return 1;
     }
 
@@ -351,6 +463,14 @@ public class SubscriptionManagementService(
       var lapsed = await repo.MarkCancelled(sub.Id);
       if (!lapsed.IsSuccess()) return lapsed.FailureOrDefault()!;
       await this.ReconcileHabitPauseSafe(rec.UserId, SubscriptionService.FreeTier);
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = rec.UserId,
+        EventType = SubscriptionEventType.Lapsed,
+        OccurredAt = nowUtc,
+        Tier = rec.Tier,
+        PeriodEnd = rec.PeriodEnd
+      });
       await notifier.NotifySubscriptionEnded(rec.UserId, rec.Tier, nowUtc);
       return 1;
     }
@@ -386,7 +506,7 @@ public class SubscriptionManagementService(
           purpose: ConsentPurpose.Subscription);
 
         if (reconcile.IsSuccess() && reconcile.Get().Status == "SUCCEEDED")
-          return await this.RollRenewedPeriod(sub, targetTier);
+          return await this.RollRenewedPeriod(sub, targetTier, plan.Price);
 
         // Only a DEFINITIVE decline (REQUIRES_PAYMENT_METHOD after a confirm
         // attempt) may fall through to a fresh attempt. A transient error
@@ -426,7 +546,19 @@ public class SubscriptionManagementService(
         purpose: ConsentPurpose.Subscription);
 
       if (chargeRes.IsSuccess() && chargeRes.Get().Status == "SUCCEEDED")
-        return await this.RollRenewedPeriod(sub, targetTier);
+        return await this.RollRenewedPeriod(sub, targetTier, plan.Price);
+
+      await this.LogEventSafe(new SubscriptionEventRecord
+      {
+        UserId = rec.UserId,
+        EventType = SubscriptionEventType.ChargeFailed,
+        OccurredAt = nowUtc,
+        Tier = targetTier,
+        AmountCents = ToCents(plan.Price),
+        Currency = plan.Price.Currency.Code,
+        PeriodEnd = rec.PeriodEnd,
+        Detail = chargeRes.IsSuccess() ? chargeRes.Get().Status : chargeRes.FailureOrDefault()?.Message
+      });
 
       // Not settled (declined, requires action, no consent, transient error):
       // enter/stay in Grace and let tomorrow's pass retry until the window lapses.
@@ -436,6 +568,15 @@ public class SubscriptionManagementService(
       {
         var graced = await repo.MarkGrace(sub.Id);
         if (!graced.IsSuccess()) return graced.FailureOrDefault()!;
+        await this.LogEventSafe(new SubscriptionEventRecord
+        {
+          UserId = rec.UserId,
+          EventType = SubscriptionEventType.GraceEntered,
+          OccurredAt = nowUtc,
+          Tier = rec.Tier,
+          PeriodEnd = rec.PeriodEnd,
+          Detail = $"grace until {rec.PeriodEnd.AddDays(plan.GracePeriodDays):yyyy-MM-dd}"
+        });
         await notifier.NotifySubscriptionPaymentFailed(
           rec.UserId, rec.Tier, rec.PeriodEnd.AddDays(plan.GracePeriodDays));
       }
@@ -451,7 +592,7 @@ public class SubscriptionManagementService(
     }
   }
 
-  private async Task<Result<int>> RollRenewedPeriod(UserSubscriptionPrincipal sub, string targetTier)
+  private async Task<Result<int>> RollRenewedPeriod(UserSubscriptionPrincipal sub, string targetTier, Money price)
   {
     // The new period starts where the old one ended (grace days were consumed as
     // service). The repo guard (PeriodEnd must still equal the old value) makes a
@@ -470,6 +611,16 @@ public class SubscriptionManagementService(
     // habit cap may have just shrunk. Same-tier rolls reconcile too — it's a
     // no-op there and doubles as self-healing for a previously failed pass.
     await this.ReconcileHabitPauseSafe(sub.Record.UserId, targetTier);
+    await this.LogEventSafe(new SubscriptionEventRecord
+    {
+      UserId = sub.Record.UserId,
+      EventType = SubscriptionEventType.Renewed,
+      OccurredAt = DateTime.UtcNow,
+      Tier = targetTier,
+      AmountCents = ToCents(price),
+      Currency = price.Currency.Code,
+      PeriodEnd = sub.Record.PeriodEnd.AddMonths(1)
+    });
 
     // The rolled guard above is the idempotency point: reconcile and fresh-charge
     // paths both land here, but only the pass that actually rolls emails.

--- a/UnitTest/Subscription/Fakes.cs
+++ b/UnitTest/Subscription/Fakes.cs
@@ -9,6 +9,30 @@ namespace UnitTest.Subscription;
 // matching the UnitTest/Penalty style) so the management/renewal tests can
 // assert the full state-transition matrix.
 
+// Records every appended lifecycle event; configurable failure to assert the
+// best-effort contract (an append failure must never fail the money flow).
+public sealed class FakeSubscriptionEventRepository : ISubscriptionEventRepository
+{
+  public List<SubscriptionEventRecord> Appended { get; } = [];
+  public Exception? FailWith { get; set; }
+
+  public Task<Result<SubscriptionEventPrincipal>> Append(SubscriptionEventRecord record)
+  {
+    if (FailWith is not null) return Task.FromResult<Result<SubscriptionEventPrincipal>>(FailWith);
+    Appended.Add(record);
+    return Task.FromResult<Result<SubscriptionEventPrincipal>>(
+      new SubscriptionEventPrincipal { Id = Guid.NewGuid(), Record = record });
+  }
+
+  public Task<Result<List<SubscriptionEventPrincipal>>> ListByUser(string userId, int limit)
+    => Task.FromResult<Result<List<SubscriptionEventPrincipal>>>(
+      Appended.Where(r => r.UserId == userId)
+        .OrderByDescending(r => r.OccurredAt)
+        .Take(limit)
+        .Select(r => new SubscriptionEventPrincipal { Id = Guid.NewGuid(), Record = r })
+        .ToList());
+}
+
 public sealed class FakeSubscriptionRepository : ISubscriptionRepository
 {
   private readonly Dictionary<string, UserSubscriptionPrincipal> _byUser = [];

--- a/UnitTest/Subscription/SubscriptionEventTests.cs
+++ b/UnitTest/Subscription/SubscriptionEventTests.cs
@@ -1,0 +1,186 @@
+using Domain.Notification;
+using Domain.Subscription;
+using Microsoft.Extensions.Logging.Abstractions;
+using UnitTest.Notification;
+
+namespace UnitTest.Subscription;
+
+// The append-only lifecycle history: every state/money transition writes exactly
+// the expected event, and a failed append never fails the underlying flow.
+public class SubscriptionEventTests
+{
+  private static readonly DateTime Now = new(2026, 7, 15, 0, 0, 0, DateTimeKind.Utc);
+
+  private static SubscriptionManagementService Svc(
+    FakeSubscriptionRepository repo,
+    FakeSubscriptionPaymentService payment,
+    FakeSubscriptionEventRepository events,
+    IEmailNotifier? notifier = null)
+    => new(repo, FakePlanProvider.Default(), payment,
+      notifier ?? new RecordingEmailNotifier(),
+      new Protection.FakeEntitlementService(),
+      events,
+      NullLogger<SubscriptionManagementService>.Instance);
+
+  private static UserSubscriptionPrincipal Row(
+    string userId, string tier, SubscriptionStatus status,
+    DateTime? periodEnd = null, bool cancelAtPeriodEnd = false, string? nextTier = null)
+    => new()
+    {
+      Id = Guid.NewGuid(),
+      Record = new UserSubscriptionRecord
+      {
+        UserId = userId,
+        Tier = tier,
+        Status = status,
+        PeriodStart = Now.AddMonths(-1),
+        PeriodEnd = periodEnd ?? Now.AddDays(15),
+        CancelAtPeriodEnd = cancelAtPeriodEnd,
+        NextTier = nextTier,
+        LastChargeIntentId = null,
+        LastChargeKey = null,
+        RenewingUntil = null
+      },
+      CreatedAt = Now.AddMonths(-1),
+      UpdatedAt = Now.AddMonths(-1)
+    };
+
+  [Fact]
+  public async Task Subscribe_LogsActivatedWithAmount()
+  {
+    var repo = new FakeSubscriptionRepository();
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_1"), events).Subscribe("u1", "pro");
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.Activated);
+    e.Tier.Should().Be("pro");
+    e.AmountCents.Should().Be(499);
+    e.ChargeIntentId.Should().Be("int_1");
+  }
+
+  [Fact]
+  public async Task Upgrade_LogsUpgradedWithProratedAmount()
+  {
+    // Interactive upgrades prorate against the REAL clock, so the period must
+    // straddle actual UtcNow (unlike ProcessRenewals, which takes nowUtc).
+    var repo = new FakeSubscriptionRepository(
+      Row("u1", "pro", SubscriptionStatus.Active, periodEnd: DateTime.UtcNow.AddDays(15)));
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_2"), events).Subscribe("u1", "ultimate");
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.Upgraded);
+    e.Tier.Should().Be("ultimate");
+    e.AmountCents.Should().BeGreaterThan(0).And.BeLessThan(300, "only the prorated difference is charged");
+  }
+
+  [Fact]
+  public async Task SubscribeChargeFails_LogsChargeFailed()
+  {
+    var repo = new FakeSubscriptionRepository();
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.WithStatus("int_1", "REQUIRES_PAYMENT_METHOD"), events)
+      .Subscribe("u1", "pro");
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.ChargeFailed);
+    e.Detail.Should().Be("REQUIRES_PAYMENT_METHOD");
+  }
+
+  [Fact]
+  public async Task CancelThenResume_LogsBoth()
+  {
+    var repo = new FakeSubscriptionRepository(Row("u1", "pro", SubscriptionStatus.Active));
+    var events = new FakeSubscriptionEventRepository();
+    var svc = Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_x"), events);
+
+    await svc.Cancel("u1");
+    await svc.Subscribe("u1", "pro"); // same tier while pending-cancel = resume
+
+    events.Appended.Select(e => e.EventType).Should().Equal(
+      SubscriptionEventType.CancelScheduled, SubscriptionEventType.Resumed);
+  }
+
+  [Fact]
+  public async Task ScheduleDowngradeThenUndo_LogsBoth()
+  {
+    var repo = new FakeSubscriptionRepository(Row("u1", "ultimate", SubscriptionStatus.Active));
+    var events = new FakeSubscriptionEventRepository();
+    var svc = Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_x"), events);
+
+    await svc.ChangeTier("u1", "pro");       // schedule (cheaper tier)
+    await svc.ChangeTier("u1", "ultimate");  // undo (same active tier)
+
+    events.Appended.Select(e => e.EventType).Should().Equal(
+      SubscriptionEventType.DowngradeScheduled, SubscriptionEventType.DowngradeUndone);
+    events.Appended[0].NextTier.Should().Be("pro");
+  }
+
+  [Fact]
+  public async Task RenewalRoll_LogsRenewed()
+  {
+    var repo = new FakeSubscriptionRepository(Row("u1", "pro", SubscriptionStatus.Active, Now.AddDays(-1)));
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_r1"), events).ProcessRenewals(Now, 100);
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.Renewed);
+    e.AmountCents.Should().Be(499);
+  }
+
+  [Fact]
+  public async Task RenewalFailure_LogsChargeFailedAndGraceEntered_Once()
+  {
+    var repo = new FakeSubscriptionRepository(Row("u1", "pro", SubscriptionStatus.Active, Now.AddDays(-1)));
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.WithStatus("int_r1", "REQUIRES_PAYMENT_METHOD"), events)
+      .ProcessRenewals(Now, 100);
+
+    events.Appended.Select(e => e.EventType).Should().Equal(
+      SubscriptionEventType.ChargeFailed, SubscriptionEventType.GraceEntered);
+  }
+
+  [Fact]
+  public async Task GraceExpiry_LogsLapsed()
+  {
+    var repo = new FakeSubscriptionRepository(Row("u1", "pro", SubscriptionStatus.Grace, Now.AddDays(-10)));
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.Fails(new Exception("still declined")), events)
+      .ProcessRenewals(Now, 100);
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.Lapsed);
+  }
+
+  [Fact]
+  public async Task CancelAtPeriodEndRoll_LogsCancelled()
+  {
+    var repo = new FakeSubscriptionRepository(
+      Row("u1", "pro", SubscriptionStatus.Active, Now.AddDays(-1), cancelAtPeriodEnd: true));
+    var events = new FakeSubscriptionEventRepository();
+
+    await Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_r1"), events).ProcessRenewals(Now, 100);
+
+    var e = events.Appended.Should().ContainSingle().Subject;
+    e.EventType.Should().Be(SubscriptionEventType.Cancelled);
+  }
+
+  [Fact]
+  public async Task AppendFailure_DoesNotFailTheFlow()
+  {
+    var repo = new FakeSubscriptionRepository();
+    var events = new FakeSubscriptionEventRepository { FailWith = new Exception("event db down") };
+
+    var res = await Svc(repo, FakeSubscriptionPaymentService.Succeeds("int_1"), events).Subscribe("u1", "pro");
+
+    res.IsSuccess().Should().BeTrue("history is best-effort; the money flow already committed");
+    repo.Row("u1")!.Record.Status.Should().Be(SubscriptionStatus.Active);
+  }
+}

--- a/UnitTest/Subscription/SubscriptionManagementServiceTests.cs
+++ b/UnitTest/Subscription/SubscriptionManagementServiceTests.cs
@@ -14,10 +14,12 @@ public class SubscriptionManagementServiceTests
     FakeSubscriptionPaymentService payment,
     FakePlanProvider? plans = null,
     IEmailNotifier? notifier = null,
-    Protection.FakeEntitlementService? entitlements = null)
+    Protection.FakeEntitlementService? entitlements = null,
+    FakeSubscriptionEventRepository? events = null)
     => new(repo, plans ?? FakePlanProvider.Default(), payment,
       notifier ?? new RecordingEmailNotifier(),
       entitlements ?? new Protection.FakeEntitlementService(),
+      events ?? new FakeSubscriptionEventRepository(),
       NullLogger<SubscriptionManagementService>.Instance);
 
   private static UserSubscriptionPrincipal Row(

--- a/UnitTest/Subscription/SubscriptionRenewalTests.cs
+++ b/UnitTest/Subscription/SubscriptionRenewalTests.cs
@@ -16,10 +16,12 @@ public class SubscriptionRenewalTests
     FakeSubscriptionRepository repo,
     FakeSubscriptionPaymentService payment,
     IEmailNotifier? notifier = null,
-    Protection.FakeEntitlementService? entitlements = null)
+    Protection.FakeEntitlementService? entitlements = null,
+    FakeSubscriptionEventRepository? events = null)
     => new(repo, FakePlanProvider.Default(), payment,
       notifier ?? new RecordingEmailNotifier(),
       entitlements ?? new Protection.FakeEntitlementService(),
+      events ?? new FakeSubscriptionEventRepository(),
       NullLogger<SubscriptionManagementService>.Instance);
 
   private static UserSubscriptionPrincipal DueRow(

--- a/docs/subscription-lifecycle.md
+++ b/docs/subscription-lifecycle.md
@@ -91,29 +91,30 @@ Scenarios 11–15. The renewal worker (`SubscriptionRenewalHostedService`, daily
 ### Not built ❌
 
 - **`pausedByLimit` in habit API responses** — server enforces pausing, but neon/argon can't render the paused badge yet (comes with the UX step).
-- **Append-only billing event table** (decided 2026-08-01) — see below. Also the durable home for a failed pause reconcile after a lapse (today that path only logs; any later tier event self-heals).
-- **Receipts / billing history** — no ledger exists; `LastChargeIntentId/Key` is transient and cleared.
+- **Receipts / billing history UI** — the data now exists (`SubscriptionEvents` + `GET /subscription/{userId}/events`, built 2026-08-02); the argon page on top is still open.
+- **Reconcile-retry sweeper** — a failed pause reconcile after a lapse now has a durable `lapsed` event row to retry from, but nothing sweeps it yet.
 - **Grace countdown in UI** — backend computes the deadline; API/portal never expose it. Portal still says "Renews on …" during grace.
 - **Billing preview endpoint** — the portal estimates the prorated upgrade client-side from `periodStart`/`periodEnd` (fixed 2026-08-01); a zinc-authoritative preview endpoint is still open.
 - **Undo-downgrade button** — backend supports it (#7); portal renders no affordance.
 - **`payment_intent.*` webhooks** — commented out; a 3DS-later-settled charge only recovers via the daily reconcile (pichu-only today).
 - Annual billing, trials, coupons, refunds — out of scope for now.
 
-## Planned: append-only billing event table
+## Append-only billing event table (built 2026-08-02)
 
-The live `UserSubscriptions` row stays the single source of _current_ truth. History goes to a new append-only table (never updated, never deleted):
+The live `UserSubscriptions` row stays the single source of _current_ truth. History goes to `SubscriptionEvents` — append-only (never updated, never deleted), written best-effort after each state/money change in `SubscriptionManagementService`, served newest-first by `GET /api/v1/subscription/{userId}/events`:
 
 ```text
 SubscriptionEvents
 ├─ Id, UserId, OccurredAt (UTC)
-├─ EventType: subscribed | activated | upgraded | downgrade_scheduled |
-│             downgrade_undone | downgrade_applied | cancelled | resumed |
-│             renewed | charge_failed | grace_entered | grace_recovered |
-│             lapsed | charge_succeeded
-├─ Tier / NextTier snapshot
+├─ EventType: activated | upgraded | downgradeScheduled | downgradeUndone |
+│             cancelScheduled | resumed | renewed | chargeFailed |
+│             graceEntered | lapsed | cancelled
+├─ Tier / NextTier snapshot, PeriodEnd
 ├─ AmountCents, Currency, ChargeIntentId (money events)
-└─ Metadata (json)
+└─ Detail (short human-readable context, e.g. gateway status)
 ```
+
+A `renewed` event whose Tier differs from the previous one is a scheduled downgrade landing. Appends are best-effort: the state/money write has already committed, so a failed append only costs a history row and is logged loudly. No FK to Users — financial history must survive account deletion (anonymize-retain, same seam as the penalty ledger).
 
 Written in the same transaction/flow as each state change. Powers: receipts + billing history page, audit ("did we ever schedule this downgrade?"), dunning/ops debugging, and future invoices.
 


### PR DESCRIPTION
## What

Step 4 of the subscription-lifecycle plan (ClickUp 86eyg1518). **Stacked on #76** — review only the top commit until that merges, then this rebases onto main.

New append-only `SubscriptionEvents` table — one immutable row per lifecycle event:

- `activated`, `upgraded` (incl. $0 anniversary flip), `downgradeScheduled`, `downgradeUndone`, `cancelScheduled`, `resumed`, `renewed`, `chargeFailed`, `graceEntered`, `lapsed`, `cancelled`
- Tier/NextTier snapshot, PeriodEnd, AmountCents/Currency/ChargeIntentId on money events, short `Detail` (e.g. gateway status)
- Written best-effort after each committed state/money change in `SubscriptionManagementService` — a failed append never fails the money flow (mirrors the pause-reconcile contract, tested)
- `GET /api/v1/subscription/{userId}/events?limit=` serves it newest-first — the data source for the upcoming receipts/billing-history page
- No FK to Users: financial history must survive account deletion; TODO'd into the same anonymize-retain seam as the penalty ledger
- This also creates the durable record CodeRabbit asked for on #76: a `lapsed` event row persists even when the post-lapse pause reconcile fails, so a future sweeper can retry from it (sweeper itself is follow-up)

## Tests

235 unit tests green (10 new: one per event flow + append-failure best-effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdBrWdewXDddGS6N5jaXcD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription lifecycle history covering activations, upgrades, cancellations, renewals, payment failures, grace periods, and lapses.
  * Added an authenticated API endpoint to retrieve recent subscription events in newest-first order.
  * Events include tier changes, billing details, period information, timestamps, and descriptive context.
  * Subscription operations continue successfully even if event-history recording fails.

* **Documentation**
  * Updated subscription lifecycle documentation to describe the implemented event history and lifecycle types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->